### PR TITLE
Implement first pass of adding page parameters from URL

### DIFF
--- a/src/actions/art.php
+++ b/src/actions/art.php
@@ -2,7 +2,7 @@
 namespace jbrowneuk;
 
 class Art implements Page {
-    public function render($pdo, $renderer) {
+    public function render($pdo, $renderer, $pageParams) {
         $renderer->setPageId('art');
         $renderer->assign('albumName', 'Featured');
         $renderer->assign('promotedImageIndex', -1);

--- a/src/actions/journal.php
+++ b/src/actions/journal.php
@@ -2,7 +2,7 @@
 namespace jbrowneuk;
 
 class Journal implements Page {
-    public function render($pdo, $renderer) {
+    public function render($pdo, $renderer, $pageParams) {
         try {
             $posts = get_posts($pdo);
         } catch (\PDOException $ex) {

--- a/src/actions/portfolio.php
+++ b/src/actions/portfolio.php
@@ -2,7 +2,7 @@
 namespace jbrowneuk;
 
 class Portfolio implements Page {
-    public function render($pdo, $renderer) {
+    public function render($pdo, $renderer, $pageParams) {
         $renderer->setPageId('portfolio');
         $renderer->displayPage('top-page');
     }

--- a/src/actions/projects.php
+++ b/src/actions/projects.php
@@ -2,7 +2,7 @@
 namespace jbrowneuk;
 
 class Projects implements Page {
-    public function render($pdo, $renderer) {
+    public function render($pdo, $renderer, $pageParams) {
         $renderer->setPageId('projects');
         $renderer->displayPage('projects');
     }

--- a/src/config.php
+++ b/src/config.php
@@ -3,5 +3,6 @@
 $db = './site.db';
 $defaultAction = 'portfolio';
 
-// Uncomment this and update the path if running in a subdirectory
+// Uncomment these and update the paths if running in a subdirectory
 // $scriptDirectory = '/subdirectory';
+// $styleRoot = '../..';

--- a/src/core/page.php
+++ b/src/core/page.php
@@ -2,5 +2,5 @@
 namespace jbrowneuk;
 
 interface Page {
-    public function render(\PDO $pdo, PageRenderer $renderer);
+    public function render(\PDO $pdo, PageRenderer $renderer, array $pageParams);
 }

--- a/src/core/renderer.php
+++ b/src/core/renderer.php
@@ -1,10 +1,13 @@
 <?php
+
 namespace jbrowneuk;
 
-class PortfolioRenderer extends \Smarty\Smarty {
+class PortfolioRenderer extends \Smarty\Smarty
+{
     private static $parsedown = null;
 
-    public static function modifier_parsedown($input) {
+    public static function modifier_parsedown(string $input)
+    {
         if (self::$parsedown === null) {
             self::$parsedown = new \Parsedown();
         }
@@ -12,7 +15,8 @@ class PortfolioRenderer extends \Smarty\Smarty {
         return self::$parsedown->text($input);
     }
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
 
         $this->setCompileDir('smarty/compile');
@@ -21,11 +25,17 @@ class PortfolioRenderer extends \Smarty\Smarty {
         $this->registerPlugin(\Smarty\Smarty::PLUGIN_MODIFIER, 'parsedown', '\jbrowneuk\PortfolioRenderer::modifier_parsedown');
     }
 
-    public function setPageId($id) {
+    public function setStyleRoot(string $directory) {
+        $this->assign('styleDirectory', $directory);
+    }
+
+    public function setPageId(string $id)
+    {
         $this->assign('pageId', $id);
     }
 
-    public function displayPage($template) {
+    public function displayPage(string $template)
+    {
         $this->display('pages/' . $template . '.tpl');
     }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -35,6 +35,7 @@ if (isset($_SERVER['REQUEST_URI'])) {
     $detectedAction = array_shift($pageParams);
     $requestedAction = isset($detectedAction) ? $detectedAction : $defaultAction;
 } else {
+    $pageParams = [];
     $requestedAction = $defaultAction;
 }
 
@@ -52,4 +53,4 @@ if (array_key_exists($requestedAction, $routes)) {
 }
 
 $action = new $actionClass();
-$action->render($pdo, new PortfolioRenderer());
+$action->render($pdo, new PortfolioRenderer(), $pageParams);

--- a/src/index.php
+++ b/src/index.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace jbrowneuk;
 
 // Vendor
@@ -22,6 +23,14 @@ if (!$pdo) {
     die('Could not connect to database.');
 }
 
+// Page routes
+$routes = [
+    'portfolio' => Portfolio::class,
+    'art' => Art::class,
+    'journal' => Journal::class,
+    'projects' => Projects::class
+];
+
 // Calculate action if provided
 if (isset($_SERVER['REQUEST_URI'])) {
     $requestUri = $_SERVER['REQUEST_URI'];
@@ -39,18 +48,16 @@ if (isset($_SERVER['REQUEST_URI'])) {
     $requestedAction = $defaultAction;
 }
 
-$routes = [
-    'portfolio' => Portfolio::class,
-    'art' => Art::class,
-    'journal' => Journal::class,
-    'projects' => Projects::class
-];
-
 if (array_key_exists($requestedAction, $routes)) {
     $actionClass = $routes[$requestedAction];
 } else {
     $actionClass = $routes[$defaultAction];
 }
 
+// Initialise page renderer
+$renderer = new PortfolioRenderer();
+$renderer->setStyleRoot(isset($styleRoot) ? $styleRoot : '');
+
+// Render the page
 $action = new $actionClass();
-$action->render($pdo, new PortfolioRenderer(), $pageParams);
+$action->render($pdo, $renderer, $pageParams);

--- a/src/templates/layout/html-head.tpl
+++ b/src/templates/layout/html-head.tpl
@@ -6,25 +6,21 @@
 
   <title>{block name="page-title"}Jason Browne{/block}</title>
 
-  <!-- [TODO] fix urls -->
+  <!-- [TODO] fix urls to stylesheets -->
   <!-- Third-party dependencies -->
-  <link href="../jblog/src/assets/thirdparty/normalize/normalize.css" rel="stylesheet">
+  <link href="{$styleDirectory}/jblog/src/assets/thirdparty/normalize/normalize.css" rel="stylesheet">
 
-  <!-- [TODO] fix urls -->
   <!-- Base font -->
-  <link href="../jblog/src/assets/thirdparty/nunito/nunito.css" rel="stylesheet">
+  <link href="{$styleDirectory}/jblog/src/assets/thirdparty/nunito/nunito.css" rel="stylesheet">
 
-  <!-- [TODO] fix urls -->
   <!-- Iconography -->
-  <link href="../jblog/src/assets/thirdparty/la/css/line-awesome.min.css?1.3.0" rel="stylesheet">
+  <link href="{$styleDirectory}/jblog/src/assets/thirdparty/la/css/line-awesome.min.css?1.3.0" rel="stylesheet">
 
-  <!-- [TODO] fix urls -->
   <!-- Theme -->
-  <link href="../style-bundle/palette.css?v3.1.1" rel="stylesheet">
+  <link href="{$styleDirectory}/style-bundle/palette.css?v3.1.1" rel="stylesheet">
 
-  <!-- [TODO] fix urls -->
   <!-- Component library -->
-  <link href="../style-bundle/styles.css?v3.1.1" rel="stylesheet" />
+  <link href="{$styleDirectory}/style-bundle/styles.css?v3.1.1" rel="stylesheet" />
 
   {block name="extra-stylesheets"}{/block}
 </head>

--- a/tests/actions/art.test.php
+++ b/tests/actions/art.test.php
@@ -22,12 +22,12 @@ beforeEach(function () {
 
 it('should set page id', function () {
     $this->mockRenderer->expects($this->once())->method('setPageId')->with('art');
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });
 
 function runAssignTest($context, $expectedKey)
 {
-    $context->action->render($context->mockPdo, $context->mockRenderer);
+    $context->action->render($context->mockPdo, $context->mockRenderer, []);
     return array_find($context->assignCalls, function ($value) use ($expectedKey) { return $value[0] === $expectedKey; });
 }
 
@@ -56,5 +56,5 @@ it('should display page on template', function () {
         ->method('displayPage')
         ->with('album');
 
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });

--- a/tests/actions/journal.test.php
+++ b/tests/actions/journal.test.php
@@ -27,12 +27,12 @@ beforeEach(function () {
 
 it('should set page id', function () {
     $this->mockRenderer->expects($this->once())->method('setPageId')->with('journal');
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });
 
 it('should assign post data from database', function () {
     $expectedKey = 'posts';
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 
     $result = array_find($this->assignCalls, function ($value) use ($expectedKey) { return $value[0] === $expectedKey; });
     expect([$expectedKey, []])->toBe($result);
@@ -45,5 +45,5 @@ it('should display page on template', function () {
         ->method('displayPage')
         ->with('post-list');
 
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });

--- a/tests/actions/portfolio.test.php
+++ b/tests/actions/portfolio.test.php
@@ -15,7 +15,7 @@ beforeEach(function () {
 
 it('should set page id', function () {
     $this->mockRenderer->expects($this->once())->method('setPageId')->with('portfolio');
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });
 
 it('should display page on template', function () {
@@ -25,5 +25,5 @@ it('should display page on template', function () {
         ->method('displayPage')
         ->with('top-page');
 
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });

--- a/tests/actions/projects.test.php
+++ b/tests/actions/projects.test.php
@@ -15,7 +15,7 @@ beforeEach(function () {
 
 it('should set page id', function () {
     $this->mockRenderer->expects($this->once())->method('setPageId')->with('projects');
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });
 
 it('should display page on template', function () {
@@ -25,5 +25,5 @@ it('should display page on template', function () {
         ->method('displayPage')
         ->with('projects');
 
-    $this->action->render($this->mockPdo, $this->mockRenderer);
+    $this->action->render($this->mockPdo, $this->mockRenderer, []);
 });


### PR DESCRIPTION
Allows for an action to get params from the URL, in a similar way to how the old site used the Angular router.

i.e. using the route `/art/album/page/2`:

- The `art` action will be loaded, if it is registered in the routes.
- It will be passed and array of params, currently just the rest of the URL segments as an array: `['album', 'page', '2']`

Due to this, the server will provide a different directory for a page if params are added, so I've added a way to configure the style URL base directory so the page head template doesn't need to be edited manually each time the site is deployed.