### PR TITLE
Implement error page

### DIFF
--- a/src/actions/error.php
+++ b/src/actions/error.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace jbrowneuk;
+
+class Error implements Page
+{
+  public function render($pdo, $renderer, $pageParams)
+  {
+    $renderer->setPageId('error');
+    $renderer->displayPage('error');
+  }
+}

--- a/src/css/error.css
+++ b/src/css/error.css
@@ -1,0 +1,23 @@
+.error-image {
+    padding-top: 30px;
+}
+
+.error-image img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+}
+
+#site-map {
+    display: flex;
+    justify-content: center;
+    list-style: none;
+    list-style-position: inside;
+    margin: 0;
+    padding: 0;
+}
+
+#site-map li {
+    width: 20%;
+}

--- a/src/index.php
+++ b/src/index.php
@@ -14,6 +14,7 @@ require_once './database/posts.php';
 require_once './services/github-projects.php';
 
 require_once './actions/art.php';
+require_once './actions/error.php';
 require_once './actions/journal.php';
 require_once './actions/portfolio.php';
 require_once './actions/projects.php';
@@ -26,16 +27,18 @@ if (!$pdo) {
 }
 
 // Page routes
+$errorAction = 'error';
 $routes = [
     'portfolio' => Portfolio::class,
     'art' => Art::class,
     'journal' => Journal::class,
-    'projects' => Projects::class
+    'projects' => Projects::class,
+    $errorAction => Error::class
 ];
 
 // Calculate action if provided
 if (isset($_SERVER['REQUEST_URI'])) {
-    $requestUri = $_SERVER['REQUEST_URI'];
+    $requestUri = mb_strtolower($_SERVER['REQUEST_URI']);
 
     // Drop subdirectory if it is in the request URI
     if (isset($scriptDirectory) && str_starts_with($requestUri, $scriptDirectory)) {
@@ -53,7 +56,7 @@ if (isset($_SERVER['REQUEST_URI'])) {
 if (array_key_exists($requestedAction, $routes)) {
     $actionClass = $routes[$requestedAction];
 } else {
-    $actionClass = $routes[$defaultAction];
+    $actionClass = $routes[$errorAction];
 }
 
 // Initialise page renderer

--- a/src/templates/error/link-button.tpl
+++ b/src/templates/error/link-button.tpl
@@ -1,0 +1,8 @@
+{* Smarty template: Error page link button *}
+
+<li>
+  <a href="{$link}" class="indicator">
+    <span class="title-text">{$title}</span>
+    <img class="image" src="/assets/images/indicators/{$image}.svg" alt="{$title}" />
+  </a>
+</li>

--- a/src/templates/pages/error.tpl
+++ b/src/templates/pages/error.tpl
@@ -1,0 +1,36 @@
+{* Smarty template: Error page *}
+
+{extends file="layout/wrapper.tpl"}
+
+{block name="page-title"}Jason Browne{/block}
+
+{block name="extra-stylesheets"}
+    <!-- [TODO] fix urls -->
+    <link href="./css/error.css" rel="stylesheet">
+{/block}
+
+{block name="page-content"}
+    <div id="page-hero" class="error-image">
+        <div class="container">
+            <img src="/assets/images/404-large.svg" alt="404 image" />
+        </div>
+    </div>
+    <section class="page-section background-alternate">
+        <article class="container">
+            <header>
+                <h1 data-title>Feeling lost? Don’t worry.</h1>
+            </header>
+            <p>A “404” error appears if there is a broken link or a page was moved.</p>
+            <p>
+                We all get lost, once in a while. Here’s some directions back to known
+                locations, like you'd find on street signs in the real world.
+            </p>
+            <ul id="site-map" class="button-container" data-navigation>
+                {include file="error/link-button.tpl" title="Home" image="about" link="/"}
+                {include file="error/link-button.tpl" title="Art" image="art" link="/art"}
+                {include file="error/link-button.tpl" title="Software" image="software" link="/projects/code"}
+                {include file="error/link-button.tpl" title="Journal" image="about" link="/journal"}
+            </ul>
+        </article>
+    </section>
+{/block}

--- a/tests/actions/error.test.php
+++ b/tests/actions/error.test.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace jbrowneuk;
+
+require_once 'src/core/page.php';
+require_once 'src/core/renderer.php';
+
+require_once 'src/actions/error.php';
+
+beforeEach(function () {
+  $this->mockPdo = $this->createMock(\PDO::class);
+  $this->mockRenderer = $this->createMock(PortfolioRenderer::class);
+
+  $this->action = new Error();
+});
+
+it('should set page id', function () {
+  $this->mockRenderer->expects($this->once())->method('setPageId')->with('error');
+  $this->action->render($this->mockPdo, $this->mockRenderer, []);
+});
+
+it('should display page on template', function () {
+  $this
+    ->mockRenderer
+    ->expects($this->atLeastOnce())
+    ->method('displayPage')
+    ->with('error');
+
+  $this->action->render($this->mockPdo, $this->mockRenderer, []);
+});


### PR DESCRIPTION
Implements the 404 error page for the site. This is the final end-user-facing functionality needed to replace the Angular version of the site.

Work is still needed on:
- Pagination on post list and album views (currently the latest `n` items are shown)
- Admin panel (I found myself not using this in the Angular version of the site anyway...)