### PR TITLE
Correct paths in component templates

### DIFF
--- a/src/templates/components/gallery/image-container.tpl
+++ b/src/templates/components/gallery/image-container.tpl
@@ -14,7 +14,7 @@
             <!-- Images -->
             <div id="gallery-container" class="grid-list">
                 {foreach $images as $idx=>$image}
-                    {include file="gallery/thumbnail.tpl" isPromoted="{$promotedImageIndex === $idx}"}
+                    {include file="components/gallery/thumbnail.tpl" isPromoted="{$promotedImageIndex === $idx}"}
                 {/foreach}
             </div>
         {/if}

--- a/src/templates/components/projects/list.tpl
+++ b/src/templates/components/projects/list.tpl
@@ -1,5 +1,5 @@
 {* Smarty template: project list projects container *}
 
 {foreach $projects as $project}
-    {include file='projects/project.tpl'}
+    {include file='components/projects/project.tpl'}
 {/foreach}


### PR DESCRIPTION
These changes were on my developer machine for #11 but I unfortunately forgot to push them before making the PR. This means that the site worked locally, however would not have done so if building from scratch.

This should fix the 500 error generated when loading the Projects or Art pages.