### PR TITLE
Refactor database code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ templating and [Pest](https://pestphp.com/) for the unit tests. I'm
 intentionally keeping the dependencies minimal.
 
 ## Get up and running
+The code is written for an environment using PHP 8.4, and it needs support for the SQLite PDO.
+
 Composer is used to set up dependencies. Use `composer install`.
 
 A database setup SQL file is provided in `setup/database.sql`. This will create

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
         "erusev/parsedown": "^1.7"
     },
     "require-dev": {
-        "pestphp/pest": "^3.8"
+        "pestphp/pest": "^3.8",
+        "mockery/mockery": "^1.6"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f849de0036d17915f5c79758ba0166c8",
+    "content-hash": "8c6ed2b0a7b217c8ceb901bd1bf62388",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -482,6 +482,57 @@
             "time": "2025-03-15T12:00:00+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -540,6 +591,89 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3928,10 +4062,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/src/actions/journal.php
+++ b/src/actions/journal.php
@@ -4,20 +4,25 @@ namespace jbrowneuk;
 
 class Journal implements Action
 {
-    
-
     public function render(\PDO $pdo, PortfolioRenderer $renderer, array $pageParams)
     {
         $page = parsePageNumber($pageParams);
-        $posts = get_posts($pdo, $page);
-        $pagination = get_post_pagination_data($pdo);
 
+        $postsDBO = posts_dbo_factory($pdo);
+        $posts = $postsDBO->getPosts($page);
+        $basePagination = $postsDBO->getPostPaginationData();
+
+        // Fill out pagination data
+        $pagination = ['page' => $page, ...$basePagination];
+
+        // Calculate stale cut-off date
         $years = 2;
         $staleTimestamp = time() - (60 * 60 * 24 * 365 * $years);
 
+        // Render page
         $renderer->setPageId('journal');
         $renderer->assign('posts', $posts);
-        $renderer->assign('pagination', ['page' => $page, ...$pagination]);
+        $renderer->assign('pagination', $pagination);
         $renderer->assign('staleTimestamp', $staleTimestamp);
         $renderer->displayPage('post-list');
     }

--- a/src/database/album.php
+++ b/src/database/album.php
@@ -2,208 +2,161 @@
 
 namespace jbrowneuk;
 
-// One image on each page is promoted/made large, therefore it takes up two
-// spaces. This is an odd number due to that.
-const IMAGES_PER_PAGE = 11;
-
-// The album_id of the featured album
-const FEATURED_ALBUM_ID = 'featured';
-
-// Columns to take from a database row to make up album information
-$albumColumns = ['album_id', 'name', 'description'];
-
-// Columns to take from a database row to make up image information
-$imageColumns = ['image_id', 'title', 'filename', 'description', 'timestamp', 'width', 'height'];
-
-/**
- * Gets all albums from the database
- *
- * @param \PDO $pdo a connected PDO object
- *
- * @return array all album data
- */
-function get_albums(\PDO $pdo)
+class AlbumDBO implements IAlbumDBO
 {
-    global $albumColumns;
-    $statement = $pdo->query('SELECT * FROM albums');
+    // One image on each page is promoted/made large, therefore it takes up two
+    // spaces. This is an odd number due to that.
+    const int IMAGES_PER_PAGE = 11;
 
-    $albums = [];
-    while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+    // The album_id of the featured album
+    const string FEATURED_ALBUM_ID = 'featured';
+
+    // Columns to take from a database row to make up album information
+    const array ALBUM_COLUMNS = ['album_id', 'name', 'description'];
+
+    // Columns to take from a database row to make up image information
+    const array IMAGE_COLUMNS = ['image_id', 'title', 'filename', 'description', 'timestamp', 'width', 'height'];
+
+    /**
+     * Constructs an instance of the Album Database Object
+     *
+     * @param \PDO $pdo a connected PDO object
+     */
+    public function __construct(private readonly \PDO $pdo) {}
+
+    public function getAlbums()
+    {
+        $statement = $this->pdo->query('SELECT * FROM albums');
+
+        $albums = [];
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $albums[] = $this->generateAlbumData($row);
+        }
+
+        return $albums;
+    }
+
+    public function getAlbum(string $albumId)
+    {
+        $statement = $this->pdo->prepare('SELECT * FROM albums WHERE album_id = :albumId LIMIT 1');
+        $statement->execute(['albumId' => $albumId]);
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
+        return $this->generateAlbumData($row);
+    }
+
+    public function getAlbumPaginationData(string $albumId)
+    {
+        return array(
+            'items_per_page' => self::IMAGES_PER_PAGE,
+            'total_items' => $this->getImageCountForAlbum($albumId)
+        );
+    }
+
+    public function getImagesForAlbum(string $albumId, int $page = 1)
+    {
+        $offset = ($page > 0 ? $page - 1 : 1) * self::IMAGES_PER_PAGE;
+
+        $statement = $this->pdo->prepare('SELECT *
+            FROM image_albums
+            JOIN images ON image_albums.image_id = images.image_id
+            WHERE image_albums.album_id = :albumName
+            ORDER BY images.timestamp DESC
+            LIMIT :offset, :limit');
+        $statement->execute(['albumName' => $albumId, 'offset' => $offset, 'limit' => self::IMAGES_PER_PAGE]);
+
+        $images = [];
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $images[] = $this->generateImageData($row);
+        }
+
+        return $images;
+    }
+
+    public function getAlbumsForImage(int $imageId)
+    {
+        $statement = $this->pdo->prepare('SELECT *
+            FROM image_albums
+            JOIN albums ON image_albums.album_id = albums.album_id
+            WHERE image_albums.image_id = :imageId');
+        $statement->execute(['imageId' => $imageId]);
+
+        $albums = [];
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $album = [];
+            foreach (self::ALBUM_COLUMNS as $column) {
+                $album[$column] = $row[$column];
+            }
+
+            $albums[$album['album_id']] = $album;
+        }
+
+        return $albums;
+    }
+
+    public function getImage(int $imageId)
+    {
+        $statement = $this->pdo->prepare('SELECT * FROM images WHERE image_id = :imageId');
+        $statement->execute(['imageId' => $imageId]);
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        return $this->generateImageData($row);
+    }
+
+    /**
+     * Constructs image data from a database row
+     *
+     * @param array $row the database row
+     *
+     * @return array image data array
+     */
+    private function generateImageData(array $row)
+    {
+        $image = [];
+        foreach (self::IMAGE_COLUMNS as $column) {
+            $image[$column] = $row[$column];
+        }
+
+        $image['albums'] = $this->getAlbumsForImage($image['image_id']);
+
+        // Calculate whether image is in featured album
+        if (isset($image['albums'][self::FEATURED_ALBUM_ID])) {
+            $image['featured'] = true;
+        }
+
+        return $image;
+    }
+
+    /**
+     * Constructs album data from a database row
+     *
+     * @param array $row the database row
+     *
+     * @return array album data array
+     */
+    private function generateAlbumData(array $row)
+    {
         $album = [];
-        foreach ($albumColumns as $column) {
+        foreach (self::ALBUM_COLUMNS as $column) {
             $album[$column] = $row[$column];
         }
 
-        $album['image_count'] = get_image_count_for_album($pdo, $album['album_id']);
+        $album['image_count'] = $this->getImageCountForAlbum($album['album_id']);
 
-        $albums[] = $album;
+        return $album;
     }
 
-    return $albums;
-}
-
-/**
- * Gets a specific album from the database
- *
- * @param \PDO $pdo a connected PDO object
- * @param string $albumId the ID of the album to fetch
- *
- * @return array album data for the specified album
- */
-function get_album(\PDO $pdo, string $albumId)
-{
-    global $albumColumns;
-
-    $statement = $pdo->prepare('SELECT * FROM albums WHERE album_id = :albumid LIMIT 1');
-    $statement->execute(['albumid' => $albumId]);
-    $row = $statement->fetch(\PDO::FETCH_ASSOC);
-    $album = [];
-    foreach ($albumColumns as $column) {
-        $album[$column] = $row[$column];
+    /**
+     * Gets the count of images in the specified album
+     *
+     * @param string $albumId the ID of the album to get the image count from
+     *
+     * @return int total count of images in the specified album
+     */
+    private function getImageCountForAlbum(string $albumId)
+    {
+        $statement = $this->pdo->prepare('SELECT count(image_id) AS total FROM image_albums WHERE album_id = :albumId');
+        $statement->execute(['albumId' => $albumId]);
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
+        return $row['total'];
     }
-
-    return $album;
-}
-
-/**
- * Gets the count of images in the specified album
- *
- * @param \PDO $pdo a connected PDO object
- * @param string $albumId the ID of the album to get the image count from
- *
- * @return int total count of images in the specified album
- */
-function get_image_count_for_album(\PDO $pdo, string $albumId)
-{
-    $statement = $pdo->prepare('SELECT count(image_id) AS total FROM image_albums WHERE album_id = :albumid');
-    $statement->execute(['albumid' => $albumId]);
-    $row = $statement->fetch(\PDO::FETCH_ASSOC);
-    return $row['total'];
-}
-
-/**
- * Gets the data required for pagination. Returns the expected number of items
- * for a page and the total number of items for an album.
- *
- * @param \PDO $pdo a connected PDO object
- * @param string $albumId the ID of the album to get the data from
- *
- * @return array pagination data for the specified album
- */
-function get_album_pagination_data(\PDO $pdo, string $albumId)
-{
-    return array(
-        'items_per_page' => IMAGES_PER_PAGE,
-        'total_items' => get_image_count_for_album($pdo, $albumId)
-    );
-}
-
-/**
- * Constructs image data from a database row
- *
- * @param \PDO $pdo a connected PDO object
- * @param array $row the database row
- *
- * @return array image data array
- */
-function generate_image_data(\PDO $pdo, array $row)
-{
-    global $imageColumns;
-
-    $image = [];
-    foreach ($imageColumns as $column) {
-        $image[$column] = $row[$column];
-    }
-
-    $image['albums'] = get_albums_for_image($pdo, $image['image_id']);
-
-    // Calculate whether image is in featured album
-    if (isset($image['albums'][FEATURED_ALBUM_ID])) {
-        $image['featured'] = true;
-    }
-
-    return $image;
-}
-
-/**
- * Gets a page of image data for images in a specified album
- *
- * @param \PDO $pdo a connected PDO object
- * @param string $albumId the ID of the album that contains the images
- * @param int page the page to fetch
- *
- * @return array a page of image data for the specified album
- */
-function get_images_for_album(\PDO $pdo, string $albumId, int $page = 1)
-{
-    if ($albumId === null) {
-        return [];
-    }
-
-    $offset = ($page > 0 ? $page - 1 : 1) * POSTS_PER_PAGE;
-
-    $statement = $pdo->prepare('SELECT *
-        FROM image_albums
-        JOIN images ON image_albums.image_id = images.image_id
-        WHERE image_albums.album_id = :albumname
-        ORDER BY images.timestamp DESC
-        LIMIT :offset, :limit');
-    $statement->execute(['albumname' => $albumId, 'offset' => $offset, 'limit' => IMAGES_PER_PAGE]);
-
-    $images = [];
-    while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-        $images[] = generate_image_data($pdo, $row);
-    }
-
-    return $images;
-}
-
-/**
- * Gets the album data for albums containing a specific image
- *
- * @param \PDO $pdo a connected PDO object
- * @param int $imageId the ID of the image to get album data for
- *
- * @return array album data for the albums containing the specified image
- */
-function get_albums_for_image(\PDO $pdo, int $imageId)
-{
-    global $albumColumns;
-
-    $statement = $pdo->prepare('SELECT *
-        FROM image_albums
-        JOIN albums ON image_albums.album_id = albums.album_id
-        WHERE image_albums.image_id = :imageid');
-    $statement->execute(['imageid' => $imageId]);
-
-    $albums = [];
-    while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-        $album = [];
-        foreach ($albumColumns as $column) {
-            $album[$column] = $row[$column];
-        }
-
-        $albums[$album['album_id']] = $album;
-    }
-
-    return $albums;
-}
-
-/**
- * Gets the image data for a specific image
- *
- * @param \PDO $pdo a connected PDO object
- * @param int $imageId the ID of the image to get the data for
- *
- * @return array image data for the specified image
- */
-function get_image(\PDO $pdo, int $imageId)
-{
-    global $imageColumns;
-
-    $statement = $pdo->prepare('SELECT * FROM images WHERE image_id = :imageid');
-    $statement->execute(['imageid' => $imageId]);
-    $row = $statement->fetch(\PDO::FETCH_ASSOC);
-
-    return generate_image_data($pdo, $row);
 }

--- a/src/database/factories.php
+++ b/src/database/factories.php
@@ -14,3 +14,13 @@ function posts_dbo_factory(\PDO $pdo)
 {
     return new PostsDBO($pdo);
 }
+
+/**
+ * Creates an instance of the AlbumDBO object
+ *
+ * @return IAlbumDBO an album database object
+ */
+function album_dbo_factory(\PDO $pdo): IAlbumDBO
+{
+    return new AlbumDBO($pdo);
+}

--- a/src/database/factories.php
+++ b/src/database/factories.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace jbrowneuk;
+
+/**
+ * This file is a stop-gap solution while I evaluate Inversion of Control
+ * frameworks.
+ */
+
+/**
+ * Creates an instance of the PostsDBO object
+ */
+function posts_dbo_factory(\PDO $pdo)
+{
+    return new PostsDBO($pdo);
+}

--- a/src/database/posts.php
+++ b/src/database/posts.php
@@ -2,71 +2,88 @@
 
 namespace jbrowneuk;
 
-const POSTS_PER_PAGE = 5;
-
-/**
- * Gets the total post count, optionally scoped to a specific tag
- *
- * @param \PDO $pdo a connected PDO object
- * @param ?string $tag (optional) tag to scope the count to
- *
- * @return int total count of posts in the search scope
- */
-function get_post_count(\PDO $pdo, ?string $tag = null)
+class PostsDBO
 {
-    if ($tag != null && strlen($tag) > 0) {
-        $statement = $pdo->prepare('SELECT count(post_id) AS total FROM posts WHERE tags LIKE :tag');
-        $statement->execute(['tag' => "%$tag%"]);
-    } else {
-        $statement = $pdo->query('SELECT count(post_id) AS total FROM posts');
-    }
+    const POSTS_PER_PAGE = 5;
 
-    $row = $statement->fetch(\PDO::FETCH_ASSOC);
-    return $row['total'];
-}
+    /**
+     * Constructs an instance of the Posts Database Object
+     *
+     * @param \PDO $pdo a connected PDO object
+     */
+    public function __construct(private readonly \PDO $pdo) {}
 
-function get_post_pagination_data(\PDO $pdo, ?string $tag = null)
-{
-    return array(
-        'items_per_page' => POSTS_PER_PAGE,
-        'total_items' => get_post_count($pdo, $tag)
-    );
-}
-
-/**
- * Gets a page of post data, optionally scoped to a specific tag
- *
- * @param \PDO $pdo a connected PDO object
- * @param int $page the page to get data from, defaults to 1
- * @param ?string $tag (optional) tag to scope the count to
- *
- * @return array array of post data
- */
-function get_posts(\PDO $pdo, int $page = 1, ?string $tag = null)
-{
-    $offset = ($page > 0 ? $page - 1 : 1) * POSTS_PER_PAGE;
-    $params = ['offset' => $offset, 'limit' => POSTS_PER_PAGE];
-
-    if ($tag !== null && strlen($tag) > 0) {
-        $sql = 'SELECT * FROM posts WHERE tags LIKE :tag ORDER BY timestamp DESC LIMIT :offset, :limit';
-        $params['tag'] = "%$tag%";
-    } else {
-        $sql = 'SELECT * FROM posts ORDER BY timestamp DESC LIMIT :offset, :limit';
-    }
-
-    $statement = $pdo->prepare($sql);
-    $statement->execute($params);
-
-    $posts = [];
-    while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-        $post = [];
-        $cols = ['post_id', 'title', 'content', 'timestamp', 'modified_timestamp', 'tags'];
-        foreach ($cols as $column) {
-            $post[$column] = $row[$column];
+    /**
+     * Gets the total post count, optionally scoped to a specific tag
+     *
+     * @param ?string $tag (optional) tag to scope the count to
+     *
+     * @return int total count of posts in the search scope
+     */
+    public function getPostCount(?string $tag = null)
+    {
+        if ($tag != null && strlen($tag) > 0) {
+            $statement = $this->pdo->prepare('SELECT count(post_id) AS total FROM posts WHERE tags LIKE :tag');
+            $statement->execute(['tag' => "%$tag%"]);
+        } else {
+            $statement = $this->pdo->query('SELECT count(post_id) AS total FROM posts');
         }
 
-        $posts[] = $post;
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
+        return $row['total'];
     }
 
-    return $posts;
+    /**
+     * Gets the data required for pagination, optionally scoped to a specific
+     * tag. Returns the expected number of posts for a page and the total
+     * number of posts.
+     *
+     * @param ?string $tag (optional) tag to scope the count to
+     *
+     * @return array pagination data (for the specified tag if provided)
+     */
+    public function getPostPaginationData(?string $tag = null)
+    {
+        return array(
+            'items_per_page' => self::POSTS_PER_PAGE,
+            'total_items' => $this->getPostCount($tag)
+        );
+    }
+
+    /**
+     * Gets a page of post data, optionally scoped to a specific tag
+     *
+     * @param int $page the page to get data from, defaults to 1
+     * @param ?string $tag (optional) tag to scope the count to
+     *
+     * @return array array of post data
+     */
+    public function getPosts(int $page = 1, ?string $tag = null)
+    {
+        $offset = ($page > 0 ? $page - 1 : 1) * self::POSTS_PER_PAGE;
+        $params = ['offset' => $offset, 'limit' => self::POSTS_PER_PAGE];
+
+        if ($tag !== null && strlen($tag) > 0) {
+            $sql = 'SELECT * FROM posts WHERE tags LIKE :tag ORDER BY timestamp DESC LIMIT :offset, :limit';
+            $params['tag'] = "%$tag%";
+        } else {
+            $sql = 'SELECT * FROM posts ORDER BY timestamp DESC LIMIT :offset, :limit';
+        }
+
+        $statement = $this->pdo->prepare($sql);
+        $statement->execute($params);
+
+        $posts = [];
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $post = [];
+            $cols = ['post_id', 'title', 'content', 'timestamp', 'modified_timestamp', 'tags'];
+            foreach ($cols as $column) {
+                $post[$column] = $row[$column];
+            }
+
+            $posts[] = $post;
+        }
+
+        return $posts;
+    }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -10,6 +10,7 @@ require_once './core/renderer.php';
 
 require_once './database/album.php';
 require_once './database/connect.php';
+require_once './database/factories.php';
 require_once './database/posts.php';
 
 require_once './services/github-projects.php';

--- a/src/index.php
+++ b/src/index.php
@@ -4,6 +4,8 @@ namespace jbrowneuk;
 
 require_once '../vendor/autoload.php';
 
+require_once './interfaces/ialbumdbo.php';
+
 require_once './core/action.php';
 require_once './core/pagination.php';
 require_once './core/renderer.php';

--- a/src/interfaces/ialbumdbo.php
+++ b/src/interfaces/ialbumdbo.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace jbrowneuk;
+
+/**
+ * An interface encapsulating the Database Object pertaining to album data
+ */
+interface IAlbumDBO
+{
+    /**
+     * Gets all albums from the database
+     *
+     * @return array all album data
+     */
+    public function getAlbums();
+
+    /**
+     * Gets a specific album from the database
+     *
+     * @param string $albumId the ID of the album to fetch
+     *
+     * @return array album data for the specified album
+     */
+    public function getAlbum(string $albumId);
+
+    /**
+     * Gets the data required for pagination. Returns the expected number of items
+     * for a page and the total number of items for an album.
+     *
+     * @param string $albumId the ID of the album to get the data from
+     *
+     * @return array pagination data for the specified album
+     */
+    public function getAlbumPaginationData(string $albumId);
+
+    /**
+     * Gets a page of image data for images in a specified album
+     *
+     * @param string $albumId the ID of the album that contains the images
+     * @param int page the page to fetch
+     *
+     * @return array a page of image data for the specified album
+     */
+    public function getImagesForAlbum(string $albumId, int $page = 1);
+
+    /**
+     * Gets the album data for albums containing a specific image
+     *
+     * @param int $imageId the ID of the image to get album data for
+     *
+     * @return array album data for the albums containing the specified image
+     */
+    public function getAlbumsForImage(int $imageId);
+
+    /**
+     * Gets the image data for a specific image
+     *
+     * @param int $imageId the ID of the image to get the data for
+     *
+     * @return array image data for the specified image
+     */
+    public function getImage(int $imageId);
+}

--- a/tests/actions/art.test.php
+++ b/tests/actions/art.test.php
@@ -2,296 +2,247 @@
 
 namespace jbrowneuk;
 
-// Values set in mocks. [TODO] figure out how to make these work here instead of
-// having to define them in this way. Placing them here makes null get returned
-// from the mock functions below.
-$mockAlbumImageCount = null;
-$mockAlbum = null;
-$mockAlbum2 = null;
-$mockImageHorizontal = null;
-$mockImageVertical = null;
-$mockImage = null;
+const MOCK_PER_PAGE = 5;
+const MOCK_IMAGE_COUNT = 1024;
+const MOCK_ALBUM_1 = ['album_id' => 'id1', 'name' => 'a1', 'description' => 'desc1'];
+const MOCK_ALBUM_2 = ['album_id' => 'id2', 'name' => 'a2', 'description' => 'desc2'];
+const mockImageHorizontal = [
+    'image_id' => 1,
+    'title' => 'i',
+    'filename' => '1.jpg',
+    'description' => 'd1',
+    'timestamp' => 0,
+    'width' => 100,
+    'height' => 50
+];
+const mockImageVertical = [
+    'image_id' => 2,
+    'title' => '2',
+    'filename' => '2.jpg',
+    'description' => 'd2',
+    'timestamp' => 0,
+    'width' => 50,
+    'height' => 100
+];
 
-// Mocks
-function get_album($pdo, $albumId)
-{
-    global $mockAlbum;
-    if (!isset($mockAlbum)) {
-        $mockAlbum = [
-            'album_id' => 'album_id',
-            'name' => 'album',
-            'description' => 'album desc'
-        ];
-    }
-
-    return $mockAlbum;
-}
-
-function get_albums($pdo)
-{
-    global $mockAlbum, $mockAlbum2;
-    if (!isset($mockAlbum) || !isset($mockAlbum2)) {
-        $mockAlbum = [
-            'album_id' => 'album_id_1',
-            'name' => 'album',
-            'description' => 'album desc'
-        ];
-
-        $mockAlbum2 = [
-            'album_id' => 'album_id_2',
-            'name' => 'album',
-            'description' => 'album desc'
-        ];
-    }
-
-    return [$mockAlbum, $mockAlbum2];
-}
-
-function get_image_count_for_album($pdo, $albumId)
-{
-    global $mockAlbumImageCount;
-    if (!isset($mockAlbumImageCount)) {
-        $mockAlbumImageCount = 1024;
-    }
-
-    return $mockAlbumImageCount;
-}
-
-function get_album_pagination_data($pdo, $albumId)
-{
-    return array(
-        'items_per_page' => 5,
-        'total_items' => get_image_count_for_album($pdo, $albumId)
-    );
-}
-
-function get_images_for_album($pdo, $albumId, $page)
-{
-    global $mockImageHorizontal, $mockImageVertical;
-    if (!isset($mockImageHorizontal)) {
-        $mockImageHorizontal = [
-            'image_id' => 1,
-            'title' => 'i',
-            'filename' => '1.jpg',
-            'description' => 'd1',
-            'timestamp' => 0,
-            'width' => 100,
-            'height' => 50
-        ];
-    }
-
-    if (!isset($mockImageVertical)) {
-        $mockImageVertical = [
-            'image_id' => 2,
-            'title' => '2',
-            'filename' => '2.jpg',
-            'description' => 'd2',
-            'timestamp' => 0,
-            'width' => 50,
-            'height' => 100
-        ];
-    }
-
-    return [$mockImageHorizontal, $mockImageVertical];
-}
-
-function get_image($pdo, $imageId)
-{
-    global $mockImage;
-
-    if (!isset($mockImage)) {
-        $mockImage = [
-            'image_id' => 1,
-            'title' => 'image',
-            'filename' => 'image.jpg',
-            'description' => 'mock',
-            'timestamp' => 0,
-            'width' => 1,
-            'height' => 1
-        ];
-    }
-
-    return $mockImage;
-}
-
+require_once 'src/interfaces/ialbumdbo.php';
 require_once 'src/core/action.php';
 require_once 'src/core/renderer.php';
 
 require_once 'src/actions/art.php';
 
-beforeEach(function () {
-    $this->assignCalls = array();
-    $this->mockPdo = $this->createMock(\PDO::class);
-    $this->mockRenderer = $this->createMock(PortfolioRenderer::class);
-    $this
-        ->mockRenderer
-        ->expects($this->any())
-        ->method('assign')
-        ->with()
-        ->willReturnCallback(function ($key, $val) {
-            $this->assignCalls[] = [$key, $val];
-        });
+describe('Art Action', function () {
+    // Mock
+    class MockAlbumDBO implements IAlbumDBO
+    {
+        function getAlbum($albumId)
+        {
+            return MOCK_ALBUM_1;
+        }
 
-    $this->action = new Art();
-});
+        function getAlbums()
+        {
+            return [MOCK_ALBUM_1, MOCK_ALBUM_2];
+        }
 
-describe('modifier_album_names', function () {
-    it('should return input if not an array', function () {
-        $input = 1024;
-        $result = modifier_album_names($input);
-        expect($result)->toBe($input);
-    });
+        function getAlbumPaginationData($albumId)
+        {
+            return [
+                'items_per_page' => MOCK_PER_PAGE,
+                'total_items' => MOCK_IMAGE_COUNT
+            ];
+        }
 
-    it('should return concatenated album names separated by comma from input data', function () {
-        $input = [
-            ['name' => 'one'],
-            ['name' => 'two']
-        ];
-        $result = modifier_album_names($input);
-        expect($result)->toBe('one, two');
-    });
-});
+        function getImagesForAlbum($albumId, $page = 1)
+        {
+            return [mockImageHorizontal, mockImageVertical];
+        }
 
-function runAssignTest(object $context, array|string $params, string $expectedKey)
-{
-    if (!is_array($params)) {
-        $params = [$params];
+        function getImage($imageId)
+        {
+            return mockImageHorizontal;
+        }
+
+        function getAlbumsForImage($imageId)
+        {
+            return [MOCK_ALBUM_1];
+        }
     }
 
-    $context->action->render($context->mockPdo, $context->mockRenderer, $params);
-    return array_find($context->assignCalls, function ($value) use ($expectedKey) {
-        return $value[0] === $expectedKey;
-    });
-}
+    function album_dbo_factory(\PDO $pdo)
+    {
+        return new MockAlbumDBO($pdo);
+    }
 
-describe('Shared page rendering', function () {
-    $subAction = 'default';
-
-    it('should set page id', function () use ($subAction) {
-        $this->mockRenderer->expects($this->once())->method('setPageId')->with('art');
-        $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
-    });
-
-    it('should set imageRoot variable', function () use ($subAction) {
-        $expectedKey = 'imageRoot';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, '/media/art/'])->toBe($result);
-    });
-
-    it('should set thumbDir variable', function () use ($subAction) {
-        $expectedKey = 'thumbDir';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, 'thumbnails/'])->toBe($result);
-    });
-
-    it('should set imageDir variable', function () use ($subAction) {
-        $expectedKey = 'imageDir';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, 'images/'])->toBe($result);
-    });
-});
-
-describe('Album page behaviour', function () {
-    $subAction = 'album';
-
-    it('should assign album data', function () use ($subAction) {
-        global $mockAlbum;
-        $expectedKey = 'album';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, $mockAlbum])->toBe($result);
-    });
-
-    it('should assign promoted image index', function () use ($subAction) {
-        $expectedKey = 'promotedImageIndex';
-        $expectedValue = 1; // Set by RNG based on album name etc, known value provided
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, $expectedValue])->toBe($result);
-    });
-
-    it('should assign images', function () use ($subAction) {
-        global $mockImageHorizontal, $mockImageVertical;
-
-        $expectedKey = 'images';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, [$mockImageHorizontal, $mockImageVertical]])->toBe($result);
-    });
-
-    it('should assign total image count', function () use ($subAction) {
-        global $mockAlbumImageCount;
-        $expectedKey = 'totalImageCount';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect([$expectedKey, $mockAlbumImageCount])->toBe($result);
-    });
-
-    it('should assign pagination data', function () use ($subAction) {
-        global $mockAlbum;
-        $expectedKey = 'pagination';
-        $result = runAssignTest($this, $subAction, $expectedKey)[1];
-
-        // Expectation: this calls the mock
-        $mockPaginationData = get_album_pagination_data(null, null);
-
-        expect($result['page'])->toBe(1); // Expected default page
-        expect($result['prefix'])->toBe("/album/{$mockAlbum['album_id']}");
-        expect($result['items_per_page'])->toBe($mockPaginationData['items_per_page']);
-        expect($result['total_items'])->toBe($mockPaginationData['total_items']);
-    });
-
-    it('should display page on template', function () use ($subAction) {
+    beforeEach(function () {
+        $this->assignCalls = array();
+        $this->mockPdo = $this->createMock(\PDO::class);
+        $this->mockRenderer = $this->createMock(PortfolioRenderer::class);
         $this
             ->mockRenderer
-            ->expects($this->once())
-            ->method('displayPage')
-            ->with('album');
+            ->expects($this->any())
+            ->method('assign')
+            ->with()
+            ->willReturnCallback(function ($key, $val) {
+                $this->assignCalls[] = [$key, $val];
+            });
 
-        $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
-    });
-});
-
-describe('Image page behaviour', function () {
-    $subAction = 'view';
-
-    it('should display page without assigning image data if image id not provided', function () use ($subAction) {
-        $expectedKey = 'image';
-        $result = runAssignTest($this, $subAction, $expectedKey);
-        expect($result)->toBe(null);
+        $this->action = new Art();
     });
 
-    it('should assign image data if image id provided', function () use ($subAction) {
-        global $mockImage;
-        $expectedKey = 'image';
-        $result = runAssignTest($this, [$subAction, 569], $expectedKey);
-        expect([$expectedKey, $mockImage])->toBe($result);
+    describe('modifier_album_names', function () {
+        it('should return input if not an array', function () {
+            $input = 1024;
+            $result = modifier_album_names($input);
+            expect($result)->toBe($input);
+        });
+
+        it('should return concatenated album names separated by comma from input data', function () {
+            $input = [
+                ['name' => 'one'],
+                ['name' => 'two']
+            ];
+            $result = modifier_album_names($input);
+            expect($result)->toBe('one, two');
+        });
     });
 
-    it('should display page on template', function () use ($subAction) {
-        $this
-            ->mockRenderer
-            ->expects($this->once())
-            ->method('displayPage')
-            ->with('image');
+    function runAssignTest(object $context, array|string $params, string $expectedKey)
+    {
+        if (!is_array($params)) {
+            $params = [$params];
+        }
 
-        $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
+        $context->action->render($context->mockPdo, $context->mockRenderer, $params);
+        return array_find($context->assignCalls, function ($value) use ($expectedKey) {
+            return $value[0] === $expectedKey;
+        });
+    }
+
+    describe('Shared page rendering', function () {
+        $subAction = 'default';
+
+        it('should set page id', function () use ($subAction) {
+            $this->mockRenderer->expects($this->once())->method('setPageId')->with('art');
+            $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
+        });
+
+        it('should set imageRoot variable', function () use ($subAction) {
+            $expectedKey = 'imageRoot';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+            expect([$expectedKey, '/media/art/'])->toBe($result);
+        });
+
+        it('should set thumbDir variable', function () use ($subAction) {
+            $expectedKey = 'thumbDir';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+            expect([$expectedKey, 'thumbnails/'])->toBe($result);
+        });
+
+        it('should set imageDir variable', function () use ($subAction) {
+            $expectedKey = 'imageDir';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+            expect([$expectedKey, 'images/'])->toBe($result);
+        });
     });
-});
 
-describe('Album list behaviour', function () {
-    $subAction = 'albums';
+    describe('Album page behaviour', function () {
+        $subAction = 'album';
 
-    it('should assign album data', function () use ($subAction) {
-        global $mockAlbum, $mockAlbum2;
-        $expectedKey = 'albums';
-        $result = runAssignTest($this, [$subAction], $expectedKey);
-        expect([$expectedKey, [$mockAlbum, $mockAlbum2]])->toBe($result);
+        it('should assign album data', function () use ($subAction) {
+            $expectedKey = 'album';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+            expect([$expectedKey, MOCK_ALBUM_1])->toBe($result);
+        });
+
+        it('should assign promoted image index', function () use ($subAction) {
+            $expectedKey = 'promotedImageIndex';
+            $expectedValue = 1; // Set by RNG based on album name etc, known value provided
+            $result = runAssignTest($this, $subAction, $expectedKey);
+
+            expect([$expectedKey, $expectedValue])->toBe($result);
+        });
+
+        it('should assign images', function () use ($subAction) {
+            $expectedKey = 'images';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+
+            expect([$expectedKey, [mockImageHorizontal, mockImageVertical]])->toBe($result);
+        });
+
+        it('should assign total image count', function () use ($subAction) {
+            $expectedKey = 'totalImageCount';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+
+            expect([$expectedKey, MOCK_IMAGE_COUNT])->toBe($result);
+        });
+
+        it('should assign pagination data', function () use ($subAction) {
+            $expectedKey = 'pagination';
+            $result = runAssignTest($this, $subAction, $expectedKey)[1];
+
+            expect($result['page'])->toBe(1); // Expected default page
+            expect($result['prefix'])->toBe("/album/" . MOCK_ALBUM_1['album_id']);
+            expect($result['items_per_page'])->toBe(MOCK_PER_PAGE);
+            expect($result['total_items'])->toBe(MOCK_IMAGE_COUNT);
+        });
+
+        it('should display page on template', function () use ($subAction) {
+            $this
+                ->mockRenderer
+                ->expects($this->once())
+                ->method('displayPage')
+                ->with('album');
+
+            $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
+        });
     });
 
-    it('should display page on template', function () use ($subAction) {
-        $this
-            ->mockRenderer
-            ->expects($this->once())
-            ->method('displayPage')
-            ->with('album-list');
+    describe('Image page behaviour', function () {
+        $subAction = 'view';
 
-        $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
+        it('should display page without assigning image data if image id not provided', function () use ($subAction) {
+            $expectedKey = 'image';
+            $result = runAssignTest($this, $subAction, $expectedKey);
+
+            expect($result)->toBe(null);
+        });
+
+        it('should assign image data if image id provided', function () use ($subAction) {
+            $expectedKey = 'image';
+            $result = runAssignTest($this, [$subAction, 569], $expectedKey);
+
+            expect([$expectedKey, mockImageHorizontal])->toBe($result);
+        });
+
+        it('should display page on template', function () use ($subAction) {
+            $this
+                ->mockRenderer
+                ->expects($this->once())
+                ->method('displayPage')
+                ->with('image');
+
+            $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
+        });
+    });
+
+    describe('Album list behaviour', function () {
+        $subAction = 'albums';
+
+        it('should assign album data', function () use ($subAction) {
+            $expectedKey = 'albums';
+            $result = runAssignTest($this, [$subAction], $expectedKey);
+            expect([$expectedKey, [MOCK_ALBUM_1, MOCK_ALBUM_2]])->toBe($result);
+        });
+
+        it('should display page on template', function () use ($subAction) {
+            $this
+                ->mockRenderer
+                ->expects($this->once())
+                ->method('displayPage')
+                ->with('album-list');
+
+            $this->action->render($this->mockPdo, $this->mockRenderer, [$subAction]);
+        });
     });
 });

--- a/tests/actions/journal.test.php
+++ b/tests/actions/journal.test.php
@@ -2,89 +2,103 @@
 
 namespace jbrowneuk;
 
-// Mocks
-function get_posts($pdo)
-{
-    return [];
-}
-
-function get_post_pagination_data($pdo, $tag = null)
-{
-    return array(
-        'items_per_page' => 5,
-        'total_items' => 50
-    );
-}
-
 require_once 'src/core/action.php';
 require_once 'src/core/renderer.php';
 
 require_once 'src/actions/journal.php';
 
-beforeEach(function () {
-    $this->assignCalls = array();
-    $this->mockPdo = $this->createMock(\PDO::class);
-    $this->mockRenderer = $this->createMock(PortfolioRenderer::class);
-    $this
-        ->mockRenderer
-        ->expects($this->atLeastOnce())
-        ->method('assign')
-        ->with()
-        ->willReturnCallback(function ($key, $val) {
-            $this->assignCalls[] = [$key, $val];
+describe('Journal Action', function () {
+    // Mocks 
+    class MockPostsDBO
+    {
+        public function __construct(public readonly \PDO $pdo) {}
+
+        public function getPostPaginationData(?string $tag = null)
+        {
+            return array(
+                'items_per_page' => 5,
+                'total_items' => 50
+            );
+        }
+
+        public function getPosts()
+        {
+            return [];
+        }
+    }
+
+    function posts_dbo_factory(\PDO $pdo)
+    {
+        return new MockPostsDBO($pdo);
+    }
+
+    beforeEach(function () {
+        $this->assignCalls = array();
+
+        $this->mockPdo = $this->createMock(\PDO::class);
+
+        $this->mockRenderer = $this->createMock(PortfolioRenderer::class);
+        $this
+            ->mockRenderer
+            ->expects($this->atLeastOnce())
+            ->method('assign')
+            ->with()
+            ->willReturnCallback(function ($key, $val) {
+                $this->assignCalls[] = [$key, $val];
+            });
+
+        $this->action = new Journal();
+    });
+
+    it('should set page id', function () {
+        $this->mockRenderer->expects($this->once())->method('setPageId')->with('journal');
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+    });
+
+    it('should assign post data from database', function () {
+        $expectedKey = 'posts';
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+
+        $result = array_find($this->assignCalls, function ($value) use ($expectedKey) {
+            return $value[0] === $expectedKey;
         });
-
-    $this->action = new Journal();
-});
-
-it('should set page id', function () {
-    $this->mockRenderer->expects($this->once())->method('setPageId')->with('journal');
-    $this->action->render($this->mockPdo, $this->mockRenderer, []);
-});
-
-it('should assign post data from database', function () {
-    $expectedKey = 'posts';
-    $this->action->render($this->mockPdo, $this->mockRenderer, []);
-
-    $result = array_find($this->assignCalls, function ($value) use ($expectedKey) {
-        return $value[0] === $expectedKey;
+        expect([$expectedKey, []])->toBe($result);
     });
-    expect([$expectedKey, []])->toBe($result);
-});
 
-it('should display page on template', function () {
-    $this
-        ->mockRenderer
-        ->expects($this->atLeastOnce())
-        ->method('displayPage')
-        ->with('post-list');
+    it('should display page on template', function () {
+        $this
+            ->mockRenderer
+            ->expects($this->atLeastOnce())
+            ->method('displayPage')
+            ->with('post-list');
 
-    $this->action->render($this->mockPdo, $this->mockRenderer, []);
-});
-
-it('should have pagination data', function () {
-    $expectedKey = 'pagination';
-    $expectedPaginationData = array(
-        'page' => 1,
-        'items_per_page' => 5,
-        'total_items' => 50
-    );
-
-    $this->action->render($this->mockPdo, $this->mockRenderer, []);
-
-    $result = array_find($this->assignCalls, function ($value) use ($expectedKey) {
-        return $value[0] === $expectedKey;
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
     });
-    expect([$expectedKey, $expectedPaginationData])->toBe($result);
-});
 
-it('should assign stale timestamp', function () {
-    $expectedKey = 'staleTimestamp';
-    $expectedTimestamp = time() - (60 * 60 * 24 * 365 * 2);
-    $this->action->render($this->mockPdo, $this->mockRenderer, []);
+    it('should have pagination data', function () {
+        $expectedKey = 'pagination';
+        $expectedPaginationData = array(
+            'page' => 1,
+            'items_per_page' => 5,
+            'total_items' => 50
+        );
 
-    $result = array_find($this->assignCalls, function ($value) use ($expectedKey) {
-        return $value[0] === $expectedKey;
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+
+        $result = array_find($this->assignCalls, function ($value) use ($expectedKey) {
+            return $value[0] === $expectedKey;
+        });
+        expect([$expectedKey, $expectedPaginationData])->toBe($result);
     });
-    expect([$expectedKey, $expectedTimestamp])->toBe($result);
+
+    it('should assign stale timestamp', function () {
+        $expectedKey = 'staleTimestamp';
+        $expectedTimestamp = time() - (60 * 60 * 24 * 365 * 2);
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+
+        $result = array_find($this->assignCalls, function ($value) use ($expectedKey) {
+            return $value[0] === $expectedKey;
+        });
+        expect([$expectedKey, $expectedTimestamp])->toBe($result);
+    });
 });

--- a/tests/database/album.test.php
+++ b/tests/database/album.test.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace jbrowneuk;
+
+const MOCK_ALBUM = [
+    'album_id' => 'id',
+    'name' => 'name',
+    'description' => 'description'
+];
+
+const MOCK_IMAGE = [
+    'image_id' => 569,
+    'title' => 'title',
+    'filename' => 'i.jpg',
+    'description' => 'desc',
+    'timestamp' => 123456789,
+    'width' => 1024,
+    'height' => 768
+];
+
+describe('Album Database Object', function () {
+    require_once 'src/database/album.php';
+
+    beforeEach(function () {
+        $this->mockPdo = \Mockery::mock(\PDO::class);
+        $this->albumDbo = new AlbumDBO($this->mockPdo);
+    });
+
+    describe('getAlbums', function () {
+        beforeEach(function () {
+            $this->mockStatement = \Mockery::mock(\PDOStatement::class);
+            $this->mockStatement
+                ->shouldReceive('fetch')
+                ->andReturn([]);
+        });
+
+        it('should fetch all albums', function () {
+            $this->mockPdo
+                ->shouldReceive('query')
+                ->with('SELECT * FROM albums')
+                ->andReturn($this->mockStatement)
+                ->once();
+
+            expect($this->albumDbo->getAlbums())->toBe([]);
+        });
+    });
+
+    describe('getAlbum', function () {
+        beforeEach(function () {
+            $this->totalItemCount = 42;
+
+            $albumStatement = \Mockery::mock(\PDOStatement::class);
+            $albumStatement
+                ->shouldReceive('execute')
+                ->with(['albumId' => MOCK_ALBUM['album_id']])
+                ->once();
+            $albumStatement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn(MOCK_ALBUM);
+
+            $countStatement = \Mockery::mock(\PDOStatement::class);
+            $countStatement
+                ->shouldReceive('execute')
+                ->with(['albumId' => MOCK_ALBUM['album_id']])
+                ->once();
+            $countStatement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn(['total' => $this->totalItemCount]);
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT * FROM albums WHERE album_id = :albumId LIMIT 1')
+                ->andReturn($albumStatement)
+                ->once();
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT count(image_id) AS total FROM image_albums WHERE album_id = :albumId')
+                ->andReturn($countStatement)
+                ->once();
+        });
+
+        it('should fetch album by ID', function () {
+            $result = $this->albumDbo->getAlbum(MOCK_ALBUM['album_id']);
+            expect($result)->toContain(...MOCK_ALBUM);
+        });
+
+        it('should get image count for specified album', function () {
+            $result = $this->albumDbo->getAlbum(MOCK_ALBUM['album_id']);
+            expect($result['image_count'])->toBe($this->totalItemCount);
+        });
+    });
+
+    describe('getAlbumPaginationData', function () {
+        beforeEach(function () {
+            $this->totalItemCount = 42;
+
+            $statement = \Mockery::mock(\PDOStatement::class);
+            $statement
+                ->shouldReceive('execute')
+                ->with(['albumId' => MOCK_ALBUM['album_id']])
+                ->once();
+            $statement
+                ->shouldReceive('fetch')
+                ->andReturn(['total' => $this->totalItemCount]);
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT count(image_id) AS total FROM image_albums WHERE album_id = :albumId')
+                ->once()
+                ->andReturn($statement);
+
+            $this->paginationData = $this->albumDbo->getAlbumPaginationData(MOCK_ALBUM['album_id']);
+        });
+
+        it('should return max items per page', function () {
+            expect($this->paginationData['items_per_page'])->toBe(AlbumDBO::IMAGES_PER_PAGE);
+        });
+
+        it('should return image count for album', function () {
+            expect($this->paginationData['total_items'])->toBe($this->totalItemCount);
+        });
+    });
+
+    describe('getImagesForAlbum', function () {
+        it('should query database for image-album link data', function () {
+            // Don't care about the statement execution here here so no `with()`
+            $statement = \Mockery::mock(\PDOStatement::class);
+            $statement
+                ->shouldReceive('execute')
+                ->once();
+
+            $statement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn([]);
+
+            // [TODO] extract SQL statements to constants file or similar so whitespace isn't the reason a test fails
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT *
+            FROM image_albums
+            JOIN images ON image_albums.image_id = images.image_id
+            WHERE image_albums.album_id = :albumName
+            ORDER BY images.timestamp DESC
+            LIMIT :offset, :limit')
+                ->once()
+                ->andReturn($statement);
+
+            expect($this->albumDbo->getImagesForAlbum(MOCK_ALBUM['album_id']))->toBe([]);
+        });
+
+        it('should fetch images for specified album ID', function () {
+            $statement = \Mockery::mock(\PDOStatement::class);
+            $statement
+                ->shouldReceive('execute')
+                ->once()
+                ->with([
+                    'albumName' => MOCK_ALBUM['album_id'],
+                    'offset' => 0,
+                    'limit' => AlbumDBO::IMAGES_PER_PAGE
+                ]);
+
+            $statement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn([]);
+            $statement
+                ->shouldReceive('fetch')
+                ->andReturn(FALSE);
+
+            // Don't care about the actual SQL here so no `with()`
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->andReturn($statement);
+
+            expect($this->albumDbo->getImagesForAlbum(MOCK_ALBUM['album_id']))->toBe([]);
+        });
+
+        it('should fetch full image data for specified album ID', function () {
+            $imagesInAlbumStatement = \Mockery::mock(\PDOStatement::class);
+            $imagesInAlbumStatement
+                ->shouldReceive('execute')
+                ->once();
+            $imagesInAlbumStatement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn(MOCK_IMAGE);
+            $imagesInAlbumStatement
+                ->shouldReceive('fetch')
+                ->andReturn(FALSE);
+
+            $albumsForImageStatement = \Mockery::mock(\PDOStatement::class);
+            $albumsForImageStatement
+                ->shouldReceive('execute')
+                ->once()
+                ->with(['imageId' => MOCK_IMAGE['image_id']]);
+            $albumsForImageStatement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn(MOCK_ALBUM);
+            $albumsForImageStatement
+                ->shouldReceive('fetch')
+                ->andReturn(FALSE);
+
+            // [TODO] extract SQL statements to constants file or similar so whitespace isn't the reason a test fails
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT *
+            FROM image_albums
+            JOIN images ON image_albums.image_id = images.image_id
+            WHERE image_albums.album_id = :albumName
+            ORDER BY images.timestamp DESC
+            LIMIT :offset, :limit')
+                ->andReturn($imagesInAlbumStatement);
+            
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT *
+            FROM image_albums
+            JOIN albums ON image_albums.album_id = albums.album_id
+            WHERE image_albums.image_id = :imageId')
+                ->andReturn($albumsForImageStatement);
+
+            $expected = [[...MOCK_IMAGE, 'albums' => [MOCK_ALBUM['album_id'] => MOCK_ALBUM]]];
+            $actual = $this->albumDbo->getImagesForAlbum(MOCK_ALBUM['album_id']);
+
+            expect($actual)->toBe($expected);
+        });
+    });
+
+    describe('getAlbumsForImage', function () {
+        it('should query database for image-album link data', function () {
+            // Don't care about the statement execution here here so no `with()`
+            $statement = \Mockery::mock(\PDOStatement::class);
+            $statement
+                ->shouldReceive('execute')
+                ->once();
+
+            $statement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn([]);
+
+            // [TODO] extract SQL statements to constants file or similar so whitespace isn't the reason a test fails
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT *
+            FROM image_albums
+            JOIN albums ON image_albums.album_id = albums.album_id
+            WHERE image_albums.image_id = :imageId')
+                ->once()
+                ->andReturn($statement);
+
+            expect($this->albumDbo->getAlbumsForImage(1))->toBe([]);
+        });
+
+        it('should fetch albums with album_id as key for a specific image ID', function () {
+            $expectedImageId = 569;
+
+            $statement = \Mockery::mock(\PDOStatement::class);
+            $statement
+                ->shouldReceive('execute')
+                ->once()
+                ->with(['imageId' => $expectedImageId]);
+            $statement
+                ->shouldReceive('fetch')
+                ->once()
+                ->andReturn(MOCK_ALBUM);
+            $statement
+                ->shouldReceive('fetch')
+                ->andReturn(FALSE);
+
+            // Don't care about the actual SQL here so no `with()`
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->once()
+                ->andReturn($statement);
+
+            expect($this->albumDbo->getAlbumsForImage($expectedImageId))->toBe([MOCK_ALBUM['album_id'] => MOCK_ALBUM]);
+        });
+    });
+
+    describe('getImage', function () {
+        it('should query database for specified image', function () {
+            $expectedId = 569;
+
+            $statement = \Mockery::mock(\PDOStatement::class);
+            $statement
+                ->shouldReceive('execute')
+                ->once()
+                ->with(['imageId' => $expectedId]);
+            $statement
+                ->shouldReceive('fetch')
+                ->andReturn(MOCK_IMAGE);
+
+            $albumsStatement = \Mockery::mock(\PDOStatement::class);
+            $albumsStatement
+                ->shouldReceive('execute');
+            $albumsStatement
+                ->shouldReceive('fetch')
+                ->andReturn([]);
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->once()
+                ->with('SELECT * FROM images WHERE image_id = :imageId')
+                ->andReturn($statement);
+
+            // Album data query, don't care about this so return empty for anything else
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->andReturn($albumsStatement);
+
+            expect($this->albumDbo->getImage($expectedId))->toBe([...MOCK_IMAGE, 'albums' => []]);
+        });
+    });
+});

--- a/tests/database/posts.test.php
+++ b/tests/database/posts.test.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace jbrowneuk;
+
+const EXPECTED_POST_COUNT = 5;
+
+describe('Posts Database Object', function () {
+    require_once 'src/database/posts.php';
+
+    beforeEach(function () {
+        $this->mockPdo = \Mockery::mock(\PDO::class);
+    });
+
+    describe('getPostCount', function () {
+        beforeEach(function () {
+            $this->mockStatement = \Mockery::mock(\PDOStatement::class);
+            $this->mockStatement
+                ->shouldReceive('fetch')
+                ->andReturn(['total' => EXPECTED_POST_COUNT]);
+
+            $this->postsDbo = new PostsDBO($this->mockPdo);
+        });
+
+        it('should fetch post count of all posts if tag not provided', function () {
+            $this->mockPdo
+                ->shouldReceive('query')
+                ->with('SELECT count(post_id) AS total FROM posts')
+                ->andReturn($this->mockStatement)
+                ->once();
+
+            expect($this->postsDbo->getPostCount())->toBe(EXPECTED_POST_COUNT);
+        });
+
+        it('should fetch post count of tagged posts if tag is provided', function () {
+            $tag = 'anything';
+
+            $this->mockStatement
+                ->shouldReceive('execute')
+                ->with(['tag' => "%$tag%"])
+                ->once();
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT count(post_id) AS total FROM posts WHERE tags LIKE :tag')
+                ->andReturn($this->mockStatement)
+                ->once();
+
+            expect($this->postsDbo->getPostCount($tag))->toBe(EXPECTED_POST_COUNT);
+        });
+    });
+
+    describe('getPostPaginationData', function () {
+        beforeEach(function () {
+            $this->postsDbo = \Mockery::mock(PostsDBO::class)->makePartial();
+        });
+
+        it('should return items per page', function () {
+            $this->postsDbo->shouldReceive('getPostCount')->andReturn(0);
+
+            $pagination = $this->postsDbo->getPostPaginationData();
+
+            expect($pagination['items_per_page'])->toBe(PostsDBO::POSTS_PER_PAGE);
+        });
+
+        it('should return total items if tag not specified', function () {
+            $expectedCount = 16;
+
+            $this->postsDbo->shouldReceive('getPostCount')->andReturn($expectedCount);
+
+            $pagination = $this->postsDbo->getPostPaginationData();
+
+            expect($pagination['total_items'])->toBe($expectedCount);
+        });
+
+        it('should pass tag to post count', function () {
+            $tag = 'any';
+
+            $this->postsDbo->shouldReceive('getPostCount')->with($tag)->andReturn(0);
+
+            $pagination = $this->postsDbo->getPostPaginationData($tag);
+
+            expect($pagination)->toBeTruthy();
+        });
+    });
+
+    describe('getPosts', function () {
+        beforeEach(function () {
+            $this->mockStatement = \Mockery::mock(\PDOStatement::class);
+            $this->mockStatement
+                ->shouldReceive('fetch')
+                ->andReturn([]);
+
+            $this->postsDbo = new PostsDBO($this->mockPdo);
+        });
+
+        it('should fetch a page of posts if tag not provided', function () {
+            $this->mockStatement
+                ->shouldReceive('execute')
+                ->with(['offset' => 0, 'limit' => PostsDBO::POSTS_PER_PAGE])
+                ->once();
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT * FROM posts ORDER BY timestamp DESC LIMIT :offset, :limit')
+                ->andReturn($this->mockStatement)
+                ->once();
+
+            expect($this->postsDbo->getPosts(1))->toBe([]);
+        });
+
+        it('should fetch a page of posts filtered to tag if tag provided', function () {
+            $tag = 'blog-post';
+
+            $this->mockStatement
+                ->shouldReceive('execute')
+                ->with(['offset' => 0, 'limit' => PostsDBO::POSTS_PER_PAGE, 'tag' => "%$tag%"])
+                ->once();
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT * FROM posts WHERE tags LIKE :tag ORDER BY timestamp DESC LIMIT :offset, :limit')
+                ->andReturn($this->mockStatement)
+                ->once();
+
+            expect($this->postsDbo->getPosts(1, $tag))->toBe([]);
+        });
+
+        it('should calculate correct page offset', function () {
+            $page = 5;
+            $expectedOffset = ($page - 1) * PostsDBO::POSTS_PER_PAGE; // Zero-based pagination
+
+            $this->mockStatement
+                ->shouldReceive('execute')
+                ->with(['offset' => $expectedOffset, 'limit' => PostsDBO::POSTS_PER_PAGE])
+                ->once();
+
+            $this->mockPdo
+                ->shouldReceive('prepare')
+                ->with('SELECT * FROM posts ORDER BY timestamp DESC LIMIT :offset, :limit')
+                ->andReturn($this->mockStatement)
+                ->once();
+
+            expect($this->postsDbo->getPosts($page))->toBe([]);
+        });
+    });
+});


### PR DESCRIPTION
Refactors database functions into database objects. This means related database functions are placed in an object - so posts functions are placed in a Post database object. This will eventually help with unit testing with upcoming planned dependency injection work.

Currently Posts and Album database objects have been created. Further work may consolidate or split these further.