### PR TITLE
Ease deployment by updating style URLs and providing base htaccess

### DIFF
--- a/src/core/renderer.php
+++ b/src/core/renderer.php
@@ -6,6 +6,13 @@ class PortfolioRenderer extends \Smarty\Smarty
 {
     private static $parsedown = null;
 
+    /**
+     * Parses markdown to HTML text
+     *
+     * @param string $input markdown text content
+     * 
+     * @return string HTML representation of the markdown input
+     */
     public static function modifier_parsedown(string $input)
     {
         if (self::$parsedown === null) {
@@ -15,6 +22,13 @@ class PortfolioRenderer extends \Smarty\Smarty
         return self::$parsedown->text($input);
     }
 
+    /**
+     * Parses pagination data for rendering
+     *
+     * @param array $pagination paginatino data
+     *
+     * @return array pagination data
+     */
     public static function modifier_pagination(array $pagination)
     {
         $totalPages = ceil($pagination['total_items'] / $pagination['items_per_page']);
@@ -22,6 +36,9 @@ class PortfolioRenderer extends \Smarty\Smarty
         return $pages;
     }
 
+    /**
+     * Constructs an instance of the PortfolioRenderer
+     */
     public function __construct()
     {
         parent::__construct();
@@ -33,16 +50,31 @@ class PortfolioRenderer extends \Smarty\Smarty
         $this->registerPlugin(\Smarty\Smarty::PLUGIN_MODIFIER, 'pagination', '\jbrowneuk\PortfolioRenderer::modifier_pagination');
     }
 
+    /**
+     * Sets the style root directory
+     *
+     * @param string $directory root directory for all CSS URLs
+     */
     public function setStyleRoot(string $directory)
     {
-        $this->assign('styleDirectory', $directory);
+        $this->assign('styleRoot', $directory);
     }
 
+    /**
+     * Sets the page ID, used for pagination and navigation
+     *
+     * @param $stringid the page ID
+     */
     public function setPageId(string $id)
     {
         $this->assign('pageId', $id);
     }
 
+    /**
+     * Renders the page to a specified template
+     *
+     * @param string $template template name
+     */
     public function displayPage(string $template)
     {
         $this->display('pages/' . $template . '.tpl');

--- a/src/htaccess.example
+++ b/src/htaccess.example
@@ -1,0 +1,19 @@
+# =============================================================================
+# Generic error documents
+# =============================================================================
+ErrorDocument 404 /index.php
+ErrorDocument 500 /index.php
+
+# =============================================================================
+# Initialise rewrite engine
+# =============================================================================
+RewriteEngine on
+RewriteBase /
+
+# =============================================================================
+# Get index PHP for other requests
+# =============================================================================
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]

--- a/src/templates/layout/html-head.tpl
+++ b/src/templates/layout/html-head.tpl
@@ -8,22 +8,22 @@
 
     <!-- [TODO] fix urls to stylesheets -->
     <!-- Third-party dependencies -->
-    <link href="{$styleDirectory}/jblog/src/assets/thirdparty/normalize/normalize.css" rel="stylesheet">
+    <link href="{$styleRoot}/assets/thirdparty/normalize/normalize.css" rel="stylesheet">
 
     <!-- Base font -->
-    <link href="{$styleDirectory}/jblog/src/assets/thirdparty/nunito/nunito.css" rel="stylesheet">
+    <link href="{$styleRoot}/assets/thirdparty/nunito/nunito.css" rel="stylesheet">
 
     <!-- Iconography -->
-    <link href="{$styleDirectory}/jblog/src/assets/thirdparty/la/css/line-awesome.min.css?1.3.0" rel="stylesheet">
+    <link href="{$styleRoot}/assets/thirdparty/la/css/line-awesome.min.css?1.3.0" rel="stylesheet">
 
     <!-- Theme -->
-    <link href="{$styleDirectory}/style-bundle/palette.css?v3.1.1" rel="stylesheet">
+    <link href="{$styleRoot}/theme/palette.css?v3.1.1" rel="stylesheet">
 
     <!-- Component library -->
-    <link href="{$styleDirectory}/style-bundle/styles.css?v3.1.1" rel="stylesheet">
+    <link href="{$styleRoot}/theme/styles.css?v3.1.1" rel="stylesheet">
 
     <!-- Pagination components -->
-    <link href="./css/pagination.css?v202505" rel="stylesheet">
+    <link href="{$styleRoot}/css/pagination.css?v202505" rel="stylesheet">
 
     {block name="extra-stylesheets"}{/block}
 </head>

--- a/src/templates/pages/album-list.tpl
+++ b/src/templates/pages/album-list.tpl
@@ -5,8 +5,7 @@
 {block name="page-title"}Jason Browne: Gallery - All albums{/block}
 
 {block name="extra-stylesheets"}
-    <!-- [TODO] fix urls -->
-    <link href="./css/art/album-list.css" rel="stylesheet" />
+    <link href="{$styleRoot}/css/art/album-list.css" rel="stylesheet" />
 {/block}
 
 {block name="page-content"}

--- a/src/templates/pages/album.tpl
+++ b/src/templates/pages/album.tpl
@@ -5,9 +5,8 @@
 {block name="page-title"}Jason Browne: Gallery - {$album['name']}{/block}
 
 {block name="extra-stylesheets"}
-    <!-- [TODO] fix urls -->
-    <link href="./css/art/image-container.css" rel="stylesheet">
-    <link href="./css/art/thumbnails.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/art/image-container.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/art/thumbnails.css" rel="stylesheet">
 {/block}
 
 {block name="page-content"}

--- a/src/templates/pages/error.tpl
+++ b/src/templates/pages/error.tpl
@@ -5,8 +5,7 @@
 {block name="page-title"}Jason Browne{/block}
 
 {block name="extra-stylesheets"}
-    <!-- [TODO] fix urls -->
-    <link href="./css/error.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/error.css" rel="stylesheet">
 {/block}
 
 {block name="page-content"}

--- a/src/templates/pages/image.tpl
+++ b/src/templates/pages/image.tpl
@@ -5,8 +5,7 @@
 {block name="page-title"}Jason Browne: Gallery{if isset($image)} - {$image['title']}{/if}{/block}
 
 {block name="extra-stylesheets"}
-    <!-- [TODO] fix urls -->
-    <link href="./css/art/image-preview.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/art/image-preview.css" rel="stylesheet">
 {/block}
 
 {block name="page-content"}

--- a/src/templates/pages/top-page.tpl
+++ b/src/templates/pages/top-page.tpl
@@ -3,10 +3,9 @@
 {extends file="layout/wrapper.tpl"} 
 
 {block name="extra-stylesheets"}
-    <!-- [TODO] fix urls -->
-    <link href="./css/super-hero.css" rel="stylesheet">
-    <link href="./css/home-about.css" rel="stylesheet">
-    <link href="./css/home-rating-bar.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/super-hero.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/home-about.css" rel="stylesheet">
+    <link href="{$styleRoot}/css/home-rating-bar.css" rel="stylesheet">
 {/block}
 
 {block name="page-content"}


### PR DESCRIPTION
Prepare for deploying the site:
- Fix up the problematic style URLs using a new `styleRoot` variable placed into the templates.
- Provide a boilerplate htaccess file that can be tweaked to make sure the site works correctly.
  This handles the core error pages and rewriting `/site/action/modifier` URLs.