### PR TITLE
Implement use of album name parameter

### DIFF
--- a/src/database/album.php
+++ b/src/database/album.php
@@ -41,6 +41,10 @@ class AlbumDBO implements IAlbumDBO
         $statement = $this->pdo->prepare('SELECT * FROM albums WHERE album_id = :albumId LIMIT 1');
         $statement->execute(['albumId' => $albumId]);
         $row = $statement->fetch(\PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
         return $this->generateAlbumData($row);
     }
 

--- a/src/templates/components/gallery/album-hero.tpl
+++ b/src/templates/components/gallery/album-hero.tpl
@@ -1,6 +1,6 @@
 {* Smarty template: Gallery album page hero *}
 
-<section *ngIf="data" id="page-hero" class="page-section small-hero">
+<section id="page-hero" class="page-section small-hero">
     <div class="container">
         <div class="toolbar">
             <h1>{$album['name']}</h1>

--- a/src/templates/components/gallery/breadcrumbs/album.tpl
+++ b/src/templates/components/gallery/breadcrumbs/album.tpl
@@ -1,0 +1,11 @@
+{* Smarty template: album view breadcrumb *}
+
+<nav class="breadcrumbs">
+    <div class="container">
+        <ol role="navigation">
+            <li><a href="/"><i class="las la-home"></i></a></li>
+            <li><a href="/art">Art</a></li>
+            <li>{$album['name']}</li>
+        </ol>
+    </div>
+</nav>

--- a/src/templates/components/gallery/image-container.tpl
+++ b/src/templates/components/gallery/image-container.tpl
@@ -5,7 +5,7 @@
 <section class="page-section">
     <div class="container">
         {if count($images) === 0}
-            <!-- Loading failed -->
+            {* Loading failed *}
             <div>
                 <h1>
                     <i class="las la-frown" aria-hidden="true"></i>
@@ -13,7 +13,7 @@
                 </h1>
             </div>
         {else}
-            <!-- Images -->
+            {* Images *}
             <div id="gallery-container" class="grid-list">
                 {foreach $images as $idx=>$image}
                     {include file="components/gallery/thumbnail.tpl" isPromoted="{$promotedImageIndex === $idx}"}

--- a/src/templates/pages/album.tpl
+++ b/src/templates/pages/album.tpl
@@ -1,8 +1,8 @@
 {* Smarty template: Gallery album images layout *}
 
-{extends file="layout/wrapper.tpl"} 
+{extends file="layout/wrapper.tpl"}
 
-{block name="page-title"}Jason Browne: Gallery - {$album['name']}{/block}
+{block name="page-title"}Jason Browne: Gallery{if isset($album)} - {$album['name']}{/if}{/block}
 
 {block name="extra-stylesheets"}
     <link href="{$styleRoot}/css/art/image-container.css" rel="stylesheet">
@@ -10,6 +10,19 @@
 {/block}
 
 {block name="page-content"}
-    {include file="components/gallery/album-hero.tpl"}
-    {include file="components/gallery/image-container.tpl"}
+    {if isset($album)}
+        {include file="components/gallery/album-hero.tpl"}
+        {include file="components/gallery/breadcrumbs/album.tpl"}
+        {include file="components/gallery/image-container.tpl"}
+    {else}
+
+<section class="page-section text-center">
+    <h1>
+        <i class="las la-frown" aria-hidden="true"></i>
+        This album does not exist
+    </h1>
+    <p>Try going <a href="/art">back to the gallery main page</a>.</p>
+</section>
+
+    {/if}
 {/block}


### PR DESCRIPTION
Re-implements the ability to show albums other than the default one if an album is provided. Similar fixes as #18 have been made to take into account album names in the database object.