### PR TITLE
Improve view on smaller screens

### DIFF
--- a/src/css/art/thumbnails.css
+++ b/src/css/art/thumbnails.css
@@ -61,8 +61,8 @@
 
 /* Disable the multi-row or -column images on mobile */
 @media screen and (max-width: 576px) {
-  :host-context(.large.horizontal),
-  :host-context(.large.vertical) {
+  .thumbnail.large.horizontal,
+  .thumbnail.large.vertical {
     grid-column: span 1;
     grid-row: span 1;
   }

--- a/src/templates/components/global-header.tpl
+++ b/src/templates/components/global-header.tpl
@@ -10,7 +10,7 @@
                 <span class="link-text hide-sm">Jason Browne</span>
             </a>
             <ul id="nav-links">
-                {include file="./nav-link.tpl" url="/" title="portfolio" isActive="{(isset($pageId) && $pageId == 'portfolio')}"}
+                {include file="./nav-link.tpl" url="/" title="portfolio" isActive="{(isset($pageId) && $pageId == 'portfolio')}" extraClasses="hide-md hide-sm"}
                 {include file="./nav-link.tpl" url="/projects/code/" title="projects" isActive="{(isset($pageId) && $pageId == 'projects')}"}
                 {include file="./nav-link.tpl" url="/art/" title="art" isActive="{(isset($pageId) && $pageId == 'art')}"}
                 {include file="./nav-link.tpl" url="/journal/" title="posts" isActive="{(isset($pageId) && $pageId == 'journal')}"}

--- a/src/templates/components/nav-link.tpl
+++ b/src/templates/components/nav-link.tpl
@@ -1,7 +1,4 @@
 {* Smarty template: page header nav links *}
+{assign var=activeClass value=$isActive == 1 ? 'active' : ''}
 
-{if $isActive == 1}
-    <li><a href="{$url}" class="active">{$title}</a></li>
-{else}
-    <li><a href="{$url}">{$title}</a></li>
-{/if}
+<li><a href="{$url}" class="{$activeClass} {$extraClasses|default}">{$title}</a></li>


### PR DESCRIPTION
Fixes a few broken CSS selectors and temporary hacks that were used after converting from an Angular front-end:

- Angular-specific CSS selectors have been removed
- The portfolio link visibility behaviour has been reverted so that the top nav links do not overflow on mobile
- Generation of classes on the nav buttons has been simplified