### PR TITLE
Add RSS feed support for journal

### DIFF
--- a/src/actions/rss.php
+++ b/src/actions/rss.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace jbrowneuk;
+
+function calc_read_time(string $content): string {
+    $wordsPerMinute = 200;
+    $wordCount = preg_match_all('/\w+/', $content);
+    if ($wordCount === false) {
+        $wordCount = 0;
+    }
+
+    $estimatedTime = round($wordCount / $wordsPerMinute);
+    $formattedTime = $estimatedTime > 0 ? $estimatedTime : 'less than a';
+    return "$formattedTime minute read";
+}
+
+class RSS implements Action
+{
+    public function render(\PDO $pdo, PortfolioRenderer $renderer, array $pageParams)
+    {
+        $renderer->setPageId('rss');
+
+        $renderer->registerPlugin(\Smarty\Smarty::PLUGIN_MODIFIER, 'readTime', '\jbrowneuk\calc_read_time');
+
+        $postsDBO = posts_dbo_factory($pdo);
+        $posts = $postsDBO->getPosts();
+        $renderer->assign('posts', $posts);
+
+        header('Content-Type: application/rss+xml; charset=utf-8');
+        $renderer->displayPage('rss');
+    }
+}

--- a/src/index.php
+++ b/src/index.php
@@ -23,6 +23,7 @@ require_once './actions/error.php';
 require_once './actions/journal.php';
 require_once './actions/portfolio.php';
 require_once './actions/projects.php';
+require_once './actions/rss.php';
 
 require_once './config.php';
 
@@ -38,6 +39,7 @@ $routes = [
     'art' => Art::class,
     'journal' => Journal::class,
     'projects' => Projects::class,
+    'rss' => RSS::class,
     $errorAction => Error::class
 ];
 

--- a/src/templates/pages/post-list.tpl
+++ b/src/templates/pages/post-list.tpl
@@ -4,6 +4,10 @@
 
 {block name="page-title"}Jason Browne: Journal{/block}
 
+{block name="extra-stylesheets"}
+    <link href="https://jbrowne.io/rss/journal" rel="alternate" type="application/rss+xml" title="Jason Browne’s Journal">
+{/block}
+
 {block name="page-content"}
     {include file="components/journal/tag-header.tpl"}
 

--- a/src/templates/pages/rss.tpl
+++ b/src/templates/pages/rss.tpl
@@ -5,7 +5,7 @@
         <title>Jason Browne’s Journal</title>
         <link>https://jbrowne.io</link>
         <description>Journal feed for Jason Browne’s Personal Journal</description>
-        <atom:link href="http://jbrowne.io/rss" rel="self" type="application/rss+xml" />
+        <atom:link href="http://jbrowne.io/rss/journal" rel="self" type="application/rss+xml" />
 
 {foreach $posts as $post}
         <item>

--- a/src/templates/pages/rss.tpl
+++ b/src/templates/pages/rss.tpl
@@ -1,0 +1,21 @@
+{* Smarty template: Outline for RSS feed *}
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Jason Browne’s Journal</title>
+        <link>https://jbrowne.io</link>
+        <description>Journal feed for Jason Browne’s Personal Journal</description>
+        <atom:link href="http://jbrowne.io/rss" rel="self" type="application/rss+xml" />
+
+{foreach $posts as $post}
+        <item>
+            <title>{$post['title']}</title>
+            <pubDate>{$post['timestamp']|date_format:DateTime::RSS}</pubDate>
+            <link>https://jbrowne.io/journal/{$post['post_id']}</link>
+            <guid>https://jbrowne.io/journal/{$post['post_id']}</guid>
+            <description>{$post['content']|readTime}. Tagged {$post['tags']|split:' '|join:', '}</description>
+        </item>
+{/foreach}
+
+    </channel>
+</rss>

--- a/src/templates/pages/single-post.tpl
+++ b/src/templates/pages/single-post.tpl
@@ -4,6 +4,10 @@
 
 {block name="page-title"}Jason Browne: {if isset($post)}{$post['title']}{else}Not found{/if}{/block}
 
+{block name="extra-stylesheets"}
+    <link href="https://jbrowne.io/rss/journal" rel="alternate" type="application/rss+xml" title="Jason Browne’s Journal">
+{/block}
+
 {block name="page-content"}
     {if isset($post)}
         <nav class="breadcrumbs">

--- a/tests/actions/journal.test.php
+++ b/tests/actions/journal.test.php
@@ -6,35 +6,11 @@ require_once 'src/interfaces/ipostsdbo.php';
 require_once 'src/core/action.php';
 require_once 'src/core/renderer.php';
 
+require_once 'tests/mocks/post-dbo-factory.mock.php';
+
 require_once 'src/actions/journal.php';
 
-const MOCK_POST = [
-    'post_id' => 'post-id',
-    'title' => 'title',
-    'content' => 'content',
-    'timestamp' => 1234567890,
-    'modified_timestamp' => null,
-    'tags' => 'abc'
-];
-
 describe('Journal Action', function () {
-    // Mocks 
-    function posts_dbo_factory()
-    {
-        $mock = \Mockery::mock(IPostsDBO::class);
-        $mock->shouldReceive('getPostCount')->andReturn(1);
-        $mock->shouldReceive('getPostPaginationData')->andReturn([
-            'items_per_page' => 5,
-            'total_items' => 50
-        ]);
-        $mock->shouldReceive('getPosts')->andReturn([]);
-
-        $mock->shouldReceive('getPost')->with(MOCK_POST['post_id'])->andReturn(MOCK_POST);
-        $mock->shouldReceive('getPost')->andReturn(false);
-
-        return $mock;
-    }
-
     beforeEach(function () {
         $this->assignCalls = array();
 
@@ -75,7 +51,7 @@ describe('Journal Action', function () {
             $this->action->render($this->mockPdo, $this->mockRenderer, []);
 
             $result = array_find($this->assignCalls, fn($value) => $value[0] === $expectedKey);
-            expect([$expectedKey, []])->toBe($result);
+            expect([$expectedKey, [MOCK_POST]])->toBe($result);
         });
 
         it('should have pagination data', function () {

--- a/tests/actions/rss.test.php
+++ b/tests/actions/rss.test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace jbrowneuk;
+
+require_once 'src/interfaces/ipostsdbo.php';
+require_once 'src/core/action.php';
+require_once 'src/core/renderer.php';
+
+require_once 'tests/mocks/post-dbo-factory.mock.php';
+
+require_once 'src/actions/rss.php';
+
+describe('Journal RSS feed action', function () {
+    beforeEach(function () {
+        $this->assignCalls = array();
+
+        $this->mockPdo = $this->createMock(\PDO::class);
+
+        $this->mockRenderer = $this->createMock(PortfolioRenderer::class);
+        $this
+            ->mockRenderer
+            ->expects($this->atLeastOnce())
+            ->method('assign')
+            ->with()
+            ->willReturnCallback(function ($key, $val) {
+                $this->assignCalls[] = [$key, $val];
+            });
+
+        $this->action = new RSS();
+    });
+
+    it('should set page id', function () {
+        $this->mockRenderer->expects($this->once())->method('setPageId')->with('rss');
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+    });
+
+    it('should assign posts', function () {
+        $expectedKey = 'posts';
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+
+        $result = array_find($this->assignCalls, fn($value) => $value[0] === $expectedKey);
+        expect([$expectedKey, [MOCK_POST]])->toBe($result);
+    });
+
+    it('should set Content-Type header', function () {})->todo('use of header() should be refactored for easier testing');
+
+    it('should display page on template', function () {
+        $this
+            ->mockRenderer
+            ->expects($this->atLeastOnce())
+            ->method('displayPage')
+            ->with('rss');
+
+        $this->action->render($this->mockPdo, $this->mockRenderer, []);
+    });
+});

--- a/tests/actions/rss.test.php
+++ b/tests/actions/rss.test.php
@@ -54,3 +54,34 @@ describe('Journal RSS feed action', function () {
         $this->action->render($this->mockPdo, $this->mockRenderer, []);
     });
 });
+
+describe('Estimated read time calculation', function () {
+    $wordPerMinuteCount = 200;
+
+    it('should return [less than a minute read] for a zero-length text', function () {
+        $result = calc_read_time('');
+        expect($result)->toBe('less than a minute read');
+    });
+
+    it('should return [less than a minute read] for texts containing fewer than half words per minute count', function () use ($wordPerMinuteCount) {
+        $words = array_fill(0, ($wordPerMinuteCount / 2) - 1, 'A');
+        $content = join(' ', $words);
+        $result = calc_read_time($content);
+        expect($result)->toBe('less than a minute read');
+    });
+
+    it('should return [1 minute read] for texts containing words per minute count', function () use ($wordPerMinuteCount) {
+        $words = array_fill(0, $wordPerMinuteCount, 'A');
+        $content = join(' ', $words);
+        $result = calc_read_time($content);
+        expect($result)->toBe('1 minute read');
+    });
+
+    it('should calculate correct minute length for texts', function () use ($wordPerMinuteCount) {
+        $multiplier = 4;
+        $words = array_fill(0, $wordPerMinuteCount * $multiplier, 'A');
+        $content = join(' ', $words);
+        $result = calc_read_time($content);
+        expect($result)->toBe("$multiplier minute read");
+    });
+});

--- a/tests/database/posts.test.php
+++ b/tests/database/posts.test.php
@@ -2,20 +2,11 @@
 
 namespace jbrowneuk;
 
+require_once 'src/database/posts.php';
+
 const EXPECTED_POST_COUNT = 5;
 
-const MOCK_POST = [
-    'post_id' => 'post-id',
-    'title' => 'title',
-    'content' => 'content',
-    'timestamp' => 1234567890,
-    'modified_timestamp' => null,
-    'tags' => 'abc'
-];
-
 describe('Posts Database Object', function () {
-    require_once 'src/database/posts.php';
-
     beforeEach(function () {
         $this->mockStatement = \Mockery::mock(\PDOStatement::class);
         $this->mockPdo = \Mockery::mock(\PDO::class);

--- a/tests/mocks/post-dbo-factory.mock.php
+++ b/tests/mocks/post-dbo-factory.mock.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace jbrowneuk;
+
+const MOCK_POST = [
+    'post_id' => 'post-id',
+    'title' => 'title',
+    'content' => 'content',
+    'timestamp' => 1234567890,
+    'modified_timestamp' => null,
+    'tags' => 'abc'
+];
+
+function posts_dbo_factory()
+{
+    $mock = \Mockery::mock(IPostsDBO::class);
+    $mock->shouldReceive('getPostCount')->andReturn(1);
+    $mock->shouldReceive('getPostPaginationData')->andReturn([
+        'items_per_page' => 5,
+        'total_items' => 50
+    ]);
+    $mock->shouldReceive('getPosts')->andReturn([MOCK_POST]);
+
+    $mock->shouldReceive('getPost')->with(MOCK_POST['post_id'])->andReturn(MOCK_POST);
+    $mock->shouldReceive('getPost')->andReturn(false);
+
+    return $mock;
+}


### PR DESCRIPTION
Re-adds support for an RSS feed for the journal, which has been non-functional since I switched away from the Angular-powered version of the site.

While RSS feeds aren't popular nowadays, I still actively use them so decided to reimplement the functionality for personal use.