### PR TITLE
Use Script directory variable on template links

### DIFF
--- a/src/templates/components/gallery/album-card.tpl
+++ b/src/templates/components/gallery/album-card.tpl
@@ -1,6 +1,6 @@
 {* Smarty template: Gallery album list item card *}
 
-<a class="album-card" href="/art/album/{$album['album_id']}/page/1]">
+<a class="album-card" href="{$scriptDirectory}/art/album/{$album['album_id']}/page/1">
     <div class="image-area">
         <img src="{$imageRoot}{$iconDir}{$album['album_id']}.jpg" alt="icon" class="preview" />
     </div>

--- a/src/templates/components/gallery/album-hero.tpl
+++ b/src/templates/components/gallery/album-hero.tpl
@@ -8,7 +8,8 @@
             <div class="secondary-text right-side" data-image-count>
                 {$totalImageCount} {$totalImageCount === 1 ? 'image' : 'images'}
             </div>
-            <a href="/art/albums" class="button primary right-side" data-album-selector>Pick another album</a>
+            <a href="{$scriptDirectory}/art/albums" class="button primary right-side" data-album-selector>Pick another
+                album</a>
         </div>
     </div>
 </section>

--- a/src/templates/components/gallery/breadcrumbs/album.tpl
+++ b/src/templates/components/gallery/breadcrumbs/album.tpl
@@ -3,8 +3,8 @@
 <nav class="breadcrumbs">
     <div class="container">
         <ol role="navigation">
-            <li><a href="/"><i class="las la-home"></i></a></li>
-            <li><a href="/art">Art</a></li>
+            <li><a href="{$scriptDirectory}/"><i class="las la-home"></i></a></li>
+            <li><a href="{$scriptDirectory}/art">Art</a></li>
             <li>{$album['name']}</li>
         </ol>
     </div>

--- a/src/templates/components/gallery/image-description.tpl
+++ b/src/templates/components/gallery/image-description.tpl
@@ -15,7 +15,7 @@
                 <li><i aria-hidden="true" class="las la-tags"></i></li>
                 {foreach $image['albums'] as $album}
                     <li class="tag-container" data-post-tag="{$album['album_id']}">
-                        <a class="tag" href="/art/album/{$album['album_id']}">#{$album['name']}</a>
+                        <a class="tag" href="{$scriptDirectory}/art/album/{$album['album_id']}">#{$album['name']}</a>
                     </li>
                 {/foreach}
             </ul>

--- a/src/templates/components/gallery/thumbnail.tpl
+++ b/src/templates/components/gallery/thumbnail.tpl
@@ -2,7 +2,7 @@
 {assign var=promotedClass value=$isPromoted ? 'large' : 'normal'}
 {assign var=orientation value=$image['width'] > $image['height'] ? 'horizontal' : 'vertical'}
 
-<a href="/art/view/{$image['image_id']}" class="thumbnail {$promotedClass} {$orientation}">
+<a href="{$scriptDirectory}/art/view/{$image['image_id']}" class="thumbnail {$promotedClass} {$orientation}">
     <img src="{$imageRoot}{$thumbDir}{$image['filename']}" loading="lazy" alt="{$image['title']}" data-image />
     <span class="title-area">
         <span class="title-text" data-title>{$image.title}</span>

--- a/src/templates/components/global-footer.tpl
+++ b/src/templates/components/global-footer.tpl
@@ -12,10 +12,10 @@
             <div class="map-list">
                 <header>Portfolio</header>
                 <ul>
-                    <li><a href="/">Home</a></li>
-                    <li><a href="/art">Art</a></li>
-                    <li><a href="/projects/code">Projects</a></li>
-                    <li><a href="/journal">Posts</a></li>
+                    <li><a href="{$scriptDirectory}/">Home</a></li>
+                    <li><a href="{$scriptDirectory}/art">Art</a></li>
+                    <li><a href="{$scriptDirectory}/projects/code">Projects</a></li>
+                    <li><a href="{$scriptDirectory}/journal">Posts</a></li>
                 </ul>
             </div>
             <div class="map-list">

--- a/src/templates/components/global-header.tpl
+++ b/src/templates/components/global-header.tpl
@@ -3,17 +3,17 @@
 <header id="page-header">
     <div id="sticky-menu">
         <nav id="menu" class="container">
-            <a class="home-link" href="/">
+            <a class="home-link" href="{$scriptDirectory}/">
                 <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="link-icon">
                     <use href="#sitesheet-logo"></use>
                 </svg>
                 <span class="link-text hide-sm">Jason Browne</span>
             </a>
             <ul id="nav-links">
-                {include file="./nav-link.tpl" url="/" title="portfolio" isActive="{(isset($pageId) && $pageId == 'portfolio')}" extraClasses="hide-md hide-sm"}
-                {include file="./nav-link.tpl" url="/projects/code/" title="projects" isActive="{(isset($pageId) && $pageId == 'projects')}"}
-                {include file="./nav-link.tpl" url="/art/" title="art" isActive="{(isset($pageId) && $pageId == 'art')}"}
-                {include file="./nav-link.tpl" url="/journal/" title="posts" isActive="{(isset($pageId) && $pageId == 'journal')}"}
+                {include file="./nav-link.tpl" url="{$scriptDirectory}/" title="portfolio" isActive="{(isset($pageId) && $pageId == 'portfolio')}" extraClasses="hide-md hide-sm"}
+                {include file="./nav-link.tpl" url="{$scriptDirectory}/projects/code/" title="projects" isActive="{(isset($pageId) && $pageId == 'projects')}"}
+                {include file="./nav-link.tpl" url="{$scriptDirectory}/art/" title="art" isActive="{(isset($pageId) && $pageId == 'art')}"}
+                {include file="./nav-link.tpl" url="{$scriptDirectory}/journal/" title="posts" isActive="{(isset($pageId) && $pageId == 'journal')}"}
                 {block name="nav-links"}{* No extra nav links by default *}{/block}
             </ul>
         </nav>

--- a/src/templates/components/home/artworks.tpl
+++ b/src/templates/components/home/artworks.tpl
@@ -10,7 +10,7 @@
                 I spend a lot of my life being visually creative, and strive to bring
                 those skills into my daily work.
             </p>
-            <a role="button" class="button primary" routerLink="/art">
+            <a role="button" class="button primary" href="{$scriptDirectory}/art">
                 <i class="las la-rocket"></i> View the gallery
             </a>
         </div>

--- a/src/templates/components/home/software.tpl
+++ b/src/templates/components/home/software.tpl
@@ -14,7 +14,7 @@
                 I also have a very basic User Experience skill set which I am actively
                 building upon.
             </p>
-            <a role="button" class="button primary" routerLink="/projects/code">
+            <a role="button" class="button primary" href="{$scriptDirectory}/projects/code">
                 <i class="las la-code"></i> View the source
             </a>
             <a role="button" class="button neutral" href="//github.com/jbrowneuk">

--- a/src/templates/components/journal/post.tpl
+++ b/src/templates/components/journal/post.tpl
@@ -23,8 +23,8 @@
             <ul data-post-tags class="tags-area">
                 <li><i aria-hidden="true" class="las la-tags"></i></li>
                 {foreach $post['tags']|split:' ' as $tag}
-                    <li class="tag-container" data-post-tag="{$tag}"><a class="tag" href="/journal/tag/{$tag}">#{$tag}</a>
-                    </li>
+                    <li class="tag-container" data-post-tag="{$tag}"><a class="tag"
+                            href="{$scriptDirectory}/journal/tag/{$tag}">#{$tag}</a></li>
                 {/foreach}
             </ul>
         </footer>

--- a/src/templates/components/projects/hero.tpl
+++ b/src/templates/components/projects/hero.tpl
@@ -24,7 +24,7 @@
                 </p>
                 <p>
                     I also spend some of my spare time
-                    <a href="/code/lab">experimenting</a> with exciting new
+                    <a href="{$scriptDirectory}/code/lab">experimenting</a> with exciting new
                     technologies and processes in order to bridge the gap
                     between humans and the machines we use.
                 </p>

--- a/src/templates/pages/error.tpl
+++ b/src/templates/pages/error.tpl
@@ -25,10 +25,10 @@
                 locations, like you'd find on street signs in the real world.
             </p>
             <ul id="error-page-site-map" class="button-container" data-navigation>
-                {include file="components/error/link-button.tpl" title="Home" image="about" link="/"}
-                {include file="components/error/link-button.tpl" title="Art" image="art" link="/art"}
-                {include file="components/error/link-button.tpl" title="Software" image="software" link="/projects/code"}
-                {include file="components/error/link-button.tpl" title="Journal" image="about" link="/journal"}
+                {include file="components/error/link-button.tpl" title="Home" image="about" link="{$scriptDirectory}/"}
+                {include file="components/error/link-button.tpl" title="Art" image="art" link="{$scriptDirectory}/art"}
+                {include file="components/error/link-button.tpl" title="Software" image="software" link="{$scriptDirectory}/projects/code"}
+                {include file="components/error/link-button.tpl" title="Journal" image="about" link="{$scriptDirectory}/journal"}
             </ul>
         </article>
     </section>

--- a/src/templates/pages/image.tpl
+++ b/src/templates/pages/image.tpl
@@ -19,7 +19,7 @@
         <i class="las la-frown" aria-hidden="true"></i>
         This image does not exist
     </h1>
-    <p>Try going <a href="/art">back to the gallery</a>.</p>
+    <p>Try going <a href="{$scriptDirectory}/art">back to the gallery</a>.</p>
 </section>
 
     {/if}

--- a/src/templates/pages/single-post.tpl
+++ b/src/templates/pages/single-post.tpl
@@ -13,8 +13,8 @@
         <nav class="breadcrumbs">
             <div class="container">
                 <ol role="navigation">
-                    <li><a href="/"><i class="las la-home"></i></a></li>
-                    <li><a href="/journal" data-back-button>Journal</a></li>
+                    <li><a href="{$scriptDirectory}/"><i class="las la-home"></i></a></li>
+                    <li><a href="{$scriptDirectory}/journal" data-back-button>Journal</a></li>
                     <li data-title>{$post['title']}</li>
                 </ol>
             </div>
@@ -27,7 +27,7 @@
         <i class="las la-frown" aria-hidden="true"></i>
         This post does not exist
     </h1>
-    <p>Try going <a href="/journal">back to the journal</a>.</p>
+    <p>Try going <a href="{$scriptDirectory}/journal">back to the journal</a>.</p>
 </section>
     {/if}
 {/block}


### PR DESCRIPTION
This is a QOL fix for development (that also fixes a couple of typos). If the script directory variable is set, it was previously not used in the template links. This PR addresses that.

A couple of old references to the Angular `routerLink` directive have also been fixed and a square bracket on a URL was removed.