### PR TITLE
Handle case where a value is returned when page parameter is not found

### DIFF
--- a/src/core/url-helpers.php
+++ b/src/core/url-helpers.php
@@ -52,7 +52,7 @@ function getRequestedPage(string $path, string $defaultAction): array
 function getValueFromPageParams(array $pageParams, string $key): string | null
 {
     $index = array_find_key($pageParams, fn($item) => $item === $key);
-    if (!array_key_exists($index + 1, $pageParams)) {
+    if ($index === null || !array_key_exists($index + 1, $pageParams)) {
         return null;
     }
 

--- a/tests/core/url-helpers.test.php
+++ b/tests/core/url-helpers.test.php
@@ -56,6 +56,15 @@ describe('getValueFromPageParams', function () {
 
         expect($actual)->toBeNull();
     });
+
+    it('should return null if item not found in array', function () {
+        $keyToFind = 'tag';
+        $params = ['page', '3'];
+
+        $actual = getValueFromPageParams($params, $keyToFind);
+
+        expect($actual)->toBeNull();
+    });
 });
 
 describe('parsePageNumber', function () {


### PR DESCRIPTION
This change fixes the case where searching for the `tag` parameter in a page params array of `['page', 3]` would return `3` due to not checking if the array search returned `null`. Null checking was added to the array search.