### PR TITLE
Change RSS feed to show more posts

### DIFF
--- a/src/actions/rss.php
+++ b/src/actions/rss.php
@@ -17,7 +17,9 @@ class RSS
         return "$formattedTime minute read";
     }
 
-    public function __construct(private readonly IPostsDBO $postsDBO, private readonly IRenderer $renderer) {}
+    public function __construct(private readonly IPostsDBO $postsDBO, private readonly IRenderer $renderer) {
+        $this->postsDBO->setPostsPerPage(16);
+    }
 
     public function __invoke()
     {

--- a/src/database/posts.dbo.php
+++ b/src/database/posts.dbo.php
@@ -2,9 +2,32 @@
 
 namespace jbrowneuk;
 
+/**
+ * Provides all SQL statements used by the posts database object
+ */
+final class PostsSQL
+{
+    private const WHERE_TAG = 'tags LIKE :tag';
+
+    public const ORDER_POSTS = ' ORDER BY timestamp DESC LIMIT :offset, :limit';
+
+    public const SELECT_POST_COUNT = 'SELECT count(post_id) AS total FROM posts';
+    public const SELECT_POST_COUNT_TAGGED = 'SELECT count(post_id) AS total FROM posts WHERE ' . self::WHERE_TAG;
+
+    private const SELECT_POSTS_ROOT = 'SELECT * FROM posts';
+    public const SELECT_POSTS = self::SELECT_POSTS_ROOT . self::ORDER_POSTS;
+    public const SELECT_POSTS_TAGGED = self::SELECT_POSTS_ROOT . ' WHERE ' . self::WHERE_TAG . self::ORDER_POSTS;
+
+    public const SELECT_SINGLE_POST = 'SELECT * FROM posts where post_id = :postId';
+}
+
 class PostsDBO implements IPostsDBO
 {
-    const POSTS_PER_PAGE = 5;
+    /** The default number of posts per page */
+    public const DEFAULT_POSTS_PER_PAGE = 5;
+
+    /** The number of posts per page for this Database Object instance */
+    private int $postsPerPage = self::DEFAULT_POSTS_PER_PAGE;
 
     /**
      * Constructs an instance of the Posts Database Object
@@ -13,13 +36,18 @@ class PostsDBO implements IPostsDBO
      */
     public function __construct(private readonly \PDO $pdo) {}
 
+    public function setPostsPerPage(int $posts): void
+    {
+        $this->postsPerPage = $posts;
+    }
+
     public function getPostCount(?string $tag = null)
     {
         if ($tag != null && strlen($tag) > 0) {
-            $statement = $this->pdo->prepare('SELECT count(post_id) AS total FROM posts WHERE tags LIKE :tag');
+            $statement = $this->pdo->prepare(PostsSQL::SELECT_POST_COUNT_TAGGED);
             $statement->execute(['tag' => "%$tag%"]);
         } else {
-            $statement = $this->pdo->query('SELECT count(post_id) AS total FROM posts');
+            $statement = $this->pdo->query(PostsSQL::SELECT_POST_COUNT);
         }
 
         $row = $statement->fetch(\PDO::FETCH_ASSOC);
@@ -29,21 +57,21 @@ class PostsDBO implements IPostsDBO
     public function getPostPaginationData(?string $tag = null)
     {
         return array(
-            'items_per_page' => self::POSTS_PER_PAGE,
+            'items_per_page' => $this->postsPerPage,
             'total_items' => $this->getPostCount($tag)
         );
     }
 
     public function getPosts(int $page = 1, ?string $tag = null)
     {
-        $offset = ($page > 0 ? $page - 1 : 1) * self::POSTS_PER_PAGE;
-        $params = ['offset' => $offset, 'limit' => self::POSTS_PER_PAGE];
+        $offset = ($page > 0 ? $page - 1 : 1) * $this->postsPerPage;
+        $params = ['offset' => $offset, 'limit' => $this->postsPerPage];
 
         if ($tag !== null && strlen($tag) > 0) {
-            $sql = 'SELECT * FROM posts WHERE tags LIKE :tag ORDER BY timestamp DESC LIMIT :offset, :limit';
+            $sql = PostsSQL::SELECT_POSTS_TAGGED;
             $params['tag'] = "%$tag%";
         } else {
-            $sql = 'SELECT * FROM posts ORDER BY timestamp DESC LIMIT :offset, :limit';
+            $sql = PostsSQL::SELECT_POSTS;
         }
 
         $statement = $this->pdo->prepare($sql);
@@ -59,7 +87,7 @@ class PostsDBO implements IPostsDBO
 
     public function getPost(string $postId)
     {
-        $sql = 'SELECT * FROM posts where post_id = :postId';
+        $sql = PostsSQL::SELECT_SINGLE_POST;
         $statement = $this->pdo->prepare($sql);
         $statement->execute(['postId' => $postId]);
 

--- a/src/interfaces/ipostsdbo.php
+++ b/src/interfaces/ipostsdbo.php
@@ -8,6 +8,13 @@ namespace jbrowneuk;
 interface IPostsDBO
 {
     /**
+     * Updates the number of posts loaded per page
+     *
+     * @param int $posts number of posts to load per page
+     */
+    public function setPostsPerPage(int $posts): void;
+
+    /**
      * Gets the total post count, optionally scoped to a specific tag
      *
      * @param ?string $tag (optional) tag to scope the count to

--- a/src/templates/pages/rss.tpl
+++ b/src/templates/pages/rss.tpl
@@ -5,7 +5,7 @@
         <title>Jason Browne’s Journal</title>
         <link>https://jbrowne.io</link>
         <description>Journal feed for Jason Browne’s Personal Journal</description>
-        <atom:link href="http://jbrowne.io/rss/journal" rel="self" type="application/rss+xml" />
+        <atom:link href="https://jbrowne.io/rss/journal" rel="self" type="application/rss+xml" />
 
 {foreach $posts as $post}
         <item>

--- a/tests/actions/rss.test.php
+++ b/tests/actions/rss.test.php
@@ -9,7 +9,7 @@ require_once 'src/actions/rss.php';
 
 describe('Journal RSS feed action', function () {
     beforeEach(function () {
-        $this->postsDBO = \Mockery::mock(IPostsDBO::class);
+        $this->postsDBO = \Mockery::spy(IPostsDBO::class);
         $this->postsDBO->shouldReceive('getPosts')->andReturn([MOCK_POST]);
 
         $this->assignCalls = array();
@@ -28,6 +28,10 @@ describe('Journal RSS feed action', function () {
 
     it('should set page id', function () {
         $this->mockRenderer->shouldHaveReceived('setPageId')->with('rss')->once();
+    });
+
+    it('should set posts count', function () {
+        $this->postsDBO->shouldHaveReceived('setPostsPerPage')->once();
     });
 
     it('should assign posts', function () {


### PR DESCRIPTION
Bumps the number of posts in the RSS feed to 16.

Updates the Posts database object to allow adjusting the number of items that make up a page.