### PR TITLE
Convert album and image handling from array to object

### DIFF
--- a/src/actions/art.php
+++ b/src/actions/art.php
@@ -16,7 +16,7 @@ class Art
      */
     public static function albumNameFormatter(array $input): string
     {
-        $titles = array_map(fn ($album) => $album['name'], $input);
+        $titles = array_map(fn ($album) => $album->name, $input);
         return implode(', ', $titles);
     }
 
@@ -75,11 +75,11 @@ class Art
 
         $pagination = $this->albumsDBO->getAlbumPaginationData($albumId);
         $images = $this->albumsDBO->getImagesForAlbum($albumId, $page);
-        $urlPrefix = "/album/{$album['album_id']}";
+        $urlPrefix = "/album/{$album->id}";
 
         // Seed random number generator to get same promoted image per album page
         $pageImageCount = count($images) - 1; // If there's less than NUM_IMAGES on a page
-        $seed = intval($album['album_id'] . $pageImageCount . $page, 36);
+        $seed = intval($album->id . $pageImageCount . $page, 36);
         mt_srand($seed);
         $promotedIndex = mt_rand(0, $pageImageCount);
 

--- a/src/css/art/album-list.css
+++ b/src/css/art/album-list.css
@@ -3,11 +3,15 @@
     grid-column: span 3;
     overflow: hidden;
     line-height: 1;
+    min-height: 80px;
+    border-radius: var(--generic-subtle_border_radius);
+    background-color: var(--page-section_color_background-dark);
 }
 
 .album-card .image-area img {
     width: 100%;
     height: auto;
+    display: block;
 }
 
 .album-card .text-area {

--- a/src/css/art/thumbnails.css
+++ b/src/css/art/thumbnails.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   position: relative;
   border-radius: var(--generic-subtle_border_radius);
+  background-color: var(--page-section_color_background-dark);
 }
 
 .thumbnail.large.horizontal {

--- a/src/index.php
+++ b/src/index.php
@@ -10,6 +10,8 @@ require_once './interfaces/iauthenticationdbo.php';
 require_once './interfaces/ipostsdbo.php';
 require_once './interfaces/irenderer.php';
 
+require_once './model/album.php';
+require_once './model/image.php';
 require_once './model/post.php';
 
 require_once './core/authentication.php';

--- a/src/interfaces/ialbumdbo.php
+++ b/src/interfaces/ialbumdbo.php
@@ -19,9 +19,9 @@ interface IAlbumDBO
      *
      * @param string $albumId the ID of the album to fetch
      *
-     * @return array album data for the specified album
+     * @return Album album data for the specified album
      */
-    public function getAlbum(string $albumId);
+    public function getAlbum(string $albumId): ?Album;
 
     /**
      * Gets the data required for pagination. Returns the expected number of items
@@ -41,7 +41,7 @@ interface IAlbumDBO
      *
      * @return array a page of image data for the specified album
      */
-    public function getImagesForAlbum(string $albumId, int $page = 1);
+    public function getImagesForAlbum(string $albumId, int $page = 1): array;
 
     /**
      * Gets the album data for albums containing a specific image
@@ -50,14 +50,14 @@ interface IAlbumDBO
      *
      * @return array album data for the albums containing the specified image
      */
-    public function getAlbumsForImage(int $imageId);
+    public function getAlbumsForImage(int $imageId): array;
 
     /**
      * Gets the image data for a specific image
      *
      * @param int $imageId the ID of the image to get the data for
      *
-     * @return array image data for the specified image
+     * @return ?Image image data for the specified image
      */
-    public function getImage(int $imageId);
+    public function getImage(int $imageId): ?Image;
 }

--- a/src/model/album.php
+++ b/src/model/album.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace jbrowneuk;
+
+/**
+ * An object encapsulating a gallery album
+ */
+class Album
+{
+    public readonly string $id;
+    public readonly string $name;
+    public readonly string $description;
+    public ?int $imageCount;
+
+    /**
+     * Constructs album data from a database row
+     *
+     * @param array $row the database row
+     */
+    public function __construct(array $row)
+    {
+        $this->id = $row['album_id'];
+        $this->name = $row['name'];
+        $this->description = $row['description'];
+    }
+
+    public function setImageCount(int $count): void
+    {
+        $this->imageCount = $count;
+    }
+}

--- a/src/model/image.php
+++ b/src/model/image.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace jbrowneuk;
+
+/**
+ * An object encapsulating a gallery image
+ */
+class Image
+{
+    public readonly int $id;
+    public readonly string $title;
+    public readonly string $filename;
+    public readonly string $description;
+    public readonly int $timestamp;
+    public readonly int $width;
+    public readonly int $height;
+
+    public array $albums;
+    public bool $featured = false;
+
+    /**
+     * Constructs album image data from a database row
+     *
+     * @param array $row the database row
+     */
+    public function __construct(array $row)
+    {
+        $this->id = $row['image_id'];
+        $this->title = $row['title'];
+        $this->filename = $row['filename'];
+        $this->description = isset($row['description']) ? $row['description'] : '';
+        $this->timestamp = $row['timestamp'];
+        $this->width = $row['width'];
+        $this->height = $row['height'];
+    }
+
+    public function setAlbums(array $albums)
+    {
+        $this->albums = $albums;
+    }
+
+    public function setFeatured()
+    {
+        $this->featured = true;
+    }
+}

--- a/src/templates/components/gallery/album-card.tpl
+++ b/src/templates/components/gallery/album-card.tpl
@@ -1,13 +1,13 @@
 {* Smarty template: Gallery album list item card *}
 
-<a class="album-card" href="{$scriptDirectory}/art/album/{$album['album_id']}/page/1">
+<a class="album-card" href="{$scriptDirectory}/art/album/{$album->id}/page/1">
     <div class="image-area">
-        <img src="{$imageRoot}{$iconDir}{$album['album_id']}.jpg" alt="icon" class="preview" />
+        <img src="{$imageRoot}{$iconDir}{$album->id}.jpg" alt="icon" class="preview" />
     </div>
     <div class="text-area">
-        <h2>{$album['name']}</h2>
+        <h2>{$album->name}</h2>
         <div class="badge-area">
-            {$album['image_count']}
+            {$album->imageCount}
             images
         </div>
     </div>

--- a/src/templates/components/gallery/album-hero.tpl
+++ b/src/templates/components/gallery/album-hero.tpl
@@ -3,7 +3,7 @@
 <section id="page-hero" class="page-section small-hero">
     <div class="container">
         <div class="toolbar">
-            <h1>{$album['name']}</h1>
+            <h1>{$album->name}</h1>
             <div class="spacer"></div>
             <div class="secondary-text right-side" data-image-count>
                 {$totalImageCount} {$totalImageCount === 1 ? 'image' : 'images'}

--- a/src/templates/components/gallery/breadcrumbs/album.tpl
+++ b/src/templates/components/gallery/breadcrumbs/album.tpl
@@ -5,7 +5,7 @@
         <ol role="navigation">
             <li><a href="{$scriptDirectory}/"><i class="las la-home"></i></a></li>
             <li><a href="{$scriptDirectory}/art">Art</a></li>
-            <li>{$album['name']}</li>
+            <li>{$album->name}</li>
         </ol>
     </div>
 </nav>

--- a/src/templates/components/gallery/image-description.tpl
+++ b/src/templates/components/gallery/image-description.tpl
@@ -3,19 +3,19 @@
 <section class="page-section post" data-post-loaded>
     <div class="container">
         <header>
-            <h1 data-title>{$image['title']}</h1>
-            <time data-date datetime="{$image['timestamp']|date_format:c}">
-                <span data-day class="day">{$image['timestamp']|date_format:j}</span>
-                <span data-month-year class="month">{$image['timestamp']|date_format:"M Y"}</span>
+            <h1 data-title>{$image->title}</h1>
+            <time data-date datetime="{$image->timestamp|date_format:c}">
+                <span data-day class="day">{$image->timestamp|date_format:j}</span>
+                <span data-month-year class="month">{$image->timestamp|date_format:"M Y"}</span>
             </time>
         </header>
-        {$image['description']|parsedown}
+        {$image->description|parsedown}
         <footer>
             <ul data-post-tags class="tags-area">
                 <li><i aria-hidden="true" class="las la-tags"></i></li>
-                {foreach $image['albums'] as $album}
-                    <li class="tag-container" data-post-tag="{$album['album_id']}">
-                        <a class="tag" href="{$scriptDirectory}/art/album/{$album['album_id']}">#{$album['name']}</a>
+                {foreach $image->albums as $album}
+                    <li class="tag-container" data-post-tag="{$album->id}">
+                        <a class="tag" href="{$scriptDirectory}/art/album/{$album->id}">#{$album->name}</a>
                     </li>
                 {/foreach}
             </ul>

--- a/src/templates/components/gallery/image-preview.tpl
+++ b/src/templates/components/gallery/image-preview.tpl
@@ -2,9 +2,9 @@
 
 <div class="presenter container zoomed-out">
     <div class="image-area">
-        <img src="{$imageRoot}{$imageDir}{$image['filename']}" alt="{$image['title']}" class="responsive" />
-        {if isset($image['featured'])}
-            <span data-ngIf="data.featured" class="featured-badge" title="Featured">
+        <img src="{$imageRoot}{$imageDir}{$image->filename}" alt="{$image->title}" class="responsive" />
+        {if $image->featured}
+            <span class="featured-badge" title="Featured">
                 <svg>
                     <use xlink:href="#sitesheet-logo"></use>
                 </svg>

--- a/src/templates/components/gallery/thumbnail.tpl
+++ b/src/templates/components/gallery/thumbnail.tpl
@@ -1,14 +1,14 @@
 {* Smarty template: Gallery image thumbnail *}
 {assign var=promotedClass value=$isPromoted ? 'large' : 'normal'}
-{assign var=orientation value=$image['width'] > $image['height'] ? 'horizontal' : 'vertical'}
+{assign var=orientation value=$image->width > $image->height ? 'horizontal' : 'vertical'}
 
-<a href="{$scriptDirectory}/art/view/{$image['image_id']}" class="thumbnail {$promotedClass} {$orientation}">
-    <img src="{$imageRoot}{$thumbDir}{$image['filename']}" loading="lazy" alt="{$image['title']}" data-image />
+<a href="{$scriptDirectory}/art/view/{$image->id}" class="thumbnail {$promotedClass} {$orientation}">
+    <img src="{$imageRoot}{$thumbDir}{$image->filename}" loading="lazy" alt="{$image->title}" data-image />
     <span class="title-area">
-        <span class="title-text" data-title>{$image.title}</span>
-        <span class="subtitle-text" data-galleries>{$image['albums']|albumNames}</span>
+        <span class="title-text" data-title>{$image->title}</span>
+        <span class="subtitle-text" data-galleries>{$image->albums|albumNames}</span>
     </span>
-    {if isset($image['featured'])}
+    {if isset($image->featured)}
         <span class="featured-badge" title="Featured">
             <svg>
                 <use xlink:href="#sitesheet-logo"></use>

--- a/src/templates/pages/album.tpl
+++ b/src/templates/pages/album.tpl
@@ -2,7 +2,7 @@
 
 {extends file="layout/wrapper.tpl"}
 
-{block name="page-title"}Jason Browne: Gallery{if isset($album)} - {$album['name']}{/if}{/block}
+{block name="page-title"}Jason Browne: Gallery{if isset($album)} - {$album->name}{/if}{/block}
 
 {block name="extra-stylesheets"}
     <link href="{$styleRoot}/css/art/image-container.css" rel="stylesheet">
@@ -21,7 +21,7 @@
         <i class="las la-frown" aria-hidden="true"></i>
         This album does not exist
     </h1>
-    <p>Try going <a href="/art">back to the gallery main page</a>.</p>
+    <p>Try going <a href="{$scriptDirectory}/art">back to the gallery main page</a>.</p>
 </section>
 
     {/if}

--- a/src/templates/pages/image.tpl
+++ b/src/templates/pages/image.tpl
@@ -2,7 +2,7 @@
 
 {extends file="layout/wrapper.tpl"} 
 
-{block name="page-title"}Jason Browne: Gallery{if isset($image)} - {$image['title']}{/if}{/block}
+{block name="page-title"}Jason Browne: Gallery{if isset($image)} - {$image->title}{/if}{/block}
 
 {block name="extra-stylesheets"}
     <link href="{$styleRoot}/css/art/image-preview.css" rel="stylesheet">

--- a/tests/actions/art.test.php
+++ b/tests/actions/art.test.php
@@ -52,8 +52,8 @@ describe('Art Action', function () {
 
     describe('albumNameFormatter', function () {
         it('should return concatenated album names separated by comma from input data', function () {
-            $input = [['name' => 'one'], ['name' => 'two']];
-            $expected = implode(', ', array_map(fn($item) => $item['name'], $input));
+            $input = [MOCK_ALBUM_1, MOCK_ALBUM_2];
+            $expected = implode(', ', array_map(fn($item) => $item->name, $input));
             $result = Art::albumNameFormatter($input);
             expect($result)->toBe($expected);
         });
@@ -112,7 +112,7 @@ describe('Art Action', function () {
             $result = $this->assignCalls['pagination'];
 
             expect($result['page'])->toBe(1); // Expected default page
-            expect($result['prefix'])->toBe("/album/" . MOCK_ALBUM_1['album_id']);
+            expect($result['prefix'])->toBe("/album/" . MOCK_ALBUM_1_ROW['album_id']);
             expect($result['items_per_page'])->toBe(MOCK_PER_PAGE);
             expect($result['total_items'])->toBe(MOCK_IMAGE_COUNT);
         });

--- a/tests/mocks/art.mock.php
+++ b/tests/mocks/art.mock.php
@@ -2,11 +2,14 @@
 
 namespace jbrowneuk;
 
+require_once 'src/model/album.php';
+require_once 'src/model/image.php';
+
 const MOCK_PER_PAGE = 5;
 const MOCK_IMAGE_COUNT = 1024;
-const MOCK_ALBUM_1 = ['album_id' => 'id1', 'name' => 'a1', 'description' => 'desc1'];
-const MOCK_ALBUM_2 = ['album_id' => 'id2', 'name' => 'a2', 'description' => 'desc2'];
-const MOCK_IMAGE_HORIZ = [
+const MOCK_ALBUM_1_ROW = ['album_id' => 'id1', 'name' => 'a1', 'description' => 'desc1'];
+const MOCK_ALBUM_2_ROW = ['album_id' => 'id2', 'name' => 'a2', 'description' => 'desc2'];
+const MOCK_IMAGE_HORIZ_ROW = [
     'image_id' => 1,
     'title' => 'i',
     'filename' => '1.jpg',
@@ -15,7 +18,7 @@ const MOCK_IMAGE_HORIZ = [
     'width' => 100,
     'height' => 50
 ];
-const MOCK_IMAGE_VERT = [
+const MOCK_IMAGE_VERT_ROW = [
     'image_id' => 2,
     'title' => '2',
     'filename' => '2.jpg',
@@ -24,3 +27,8 @@ const MOCK_IMAGE_VERT = [
     'width' => 50,
     'height' => 100
 ];
+
+const MOCK_ALBUM_1 = new Album(MOCK_ALBUM_1_ROW);
+const MOCK_ALBUM_2 = new Album(MOCK_ALBUM_2_ROW);
+const MOCK_IMAGE_HORIZ = new Image(MOCK_IMAGE_HORIZ_ROW);
+const MOCK_IMAGE_VERT = new Image(MOCK_IMAGE_VERT_ROW);

--- a/tests/model/album.test.php
+++ b/tests/model/album.test.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace jbrowneuk;
+
+describe('Album object', function () {
+    it('should set properties correctly on creation', function () {
+        $album = new Album(MOCK_ALBUM_1_ROW);
+        expect($album->id)->toBe(MOCK_ALBUM_1_ROW['album_id']);
+        expect($album->name)->toBe(MOCK_ALBUM_1_ROW['name']);
+        expect($album->description)->toBe(MOCK_ALBUM_1_ROW['description']);
+    });
+
+    it('should set imageCount property correctly', function () {
+        $album = new Album(MOCK_ALBUM_1_ROW);
+        $expectedCount = 512;
+
+        $album->setImageCount($expectedCount);
+
+        expect($album->imageCount)->toBe($expectedCount);
+    });
+});

--- a/tests/model/image.test.php
+++ b/tests/model/image.test.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace jbrowneuk;
+
+describe('Image object', function () {
+    it('should set properties correctly on creation', function () {
+        $image = new Image(MOCK_IMAGE_HORIZ_ROW);
+        expect($image->id)->toBe(MOCK_IMAGE_HORIZ_ROW['image_id']);
+        expect($image->title)->toBe(MOCK_IMAGE_HORIZ_ROW['title']);
+        expect($image->filename)->toBe(MOCK_IMAGE_HORIZ_ROW['filename']);
+        expect($image->description)->toBe(MOCK_IMAGE_HORIZ_ROW['description']);
+        expect($image->timestamp)->toBe(MOCK_IMAGE_HORIZ_ROW['timestamp']);
+        expect($image->width)->toBe(MOCK_IMAGE_HORIZ_ROW['width']);
+        expect($image->height)->toBe(MOCK_IMAGE_HORIZ_ROW['height']);
+    });
+
+    it('should set albums property correctly', function () {
+        $image = new Image(MOCK_IMAGE_HORIZ_ROW);
+        $albums = [
+            new Album(MOCK_ALBUM_1_ROW),
+            new Album(MOCK_ALBUM_2_ROW)
+        ];
+
+        $image->setAlbums($albums);
+
+        expect($image->albums)->toEqual($albums);
+    });
+
+    it('should promote to featured', function () {
+        $image = new Image(MOCK_IMAGE_HORIZ_ROW);
+
+        expect($image->featured)->toBeFalse();
+
+        $image->setFeatured();
+
+        expect($image->featured)->toBeTrue();
+    });
+});


### PR DESCRIPTION
Converts the internal representations of the Art album and image types from associative arrays to an objects with properties. This is part of the effort to make things more strongly typed.