### PR TITLE
Bump style bundle to v3.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ My reasoning behind this is as follows:
 > for packages I pull in just to spin up Angular (the framework I used) and that
 > I have no control over made me realise that this should be simpler.
 
-This project uses a SQLite database, [Smarty](https://www.smarty.net/) for the
-templating and [Pest](https://pestphp.com/) for the unit tests. I'm
-intentionally keeping the dependencies minimal.
+This project deliberately tries to keep dependencies minimal:
+- SQLite using the built-in PHP support
+- [Smarty](https://www.smarty.net/) for templating
+- [PHP-DI](https://php-di.org) for DI
+- [Pest](https://pestphp.com/) for the unit tests
+- [Mockery](https://github.com/mockery/mockery/) for mocks
 
 ## Get up and running
 The code is written for an environment using PHP 8.4, and it needs support for
@@ -32,6 +35,11 @@ sure to read the git documentation on how to use submodules.
 TL;DR:
 - `git submodule init` on initial clone to get git to fetch the submodules.
 - `git submodule update` to fetch latest commits from the submodule repo.
+
+Updating is as simple as navigating to the submodule folder, `cd src/theme`, and
+then using `git checkout tag` to change the tag the submodule is pointing to.
+You'll also want to bump the query params in `src/templates/layout/html-head.tpl`
+to match the new tag.
 
 ## Run unit tests
 `./vendor/bin/pest`

--- a/src/templates/layout/html-head.tpl
+++ b/src/templates/layout/html-head.tpl
@@ -16,10 +16,10 @@
     <link href="{$styleRoot}/assets/thirdparty/la/css/line-awesome.min.css?1.3.0" rel="stylesheet">
 
     <!-- Theme -->
-    <link href="{$styleRoot}/theme/palette.css?v3.5.0" rel="stylesheet">
+    <link href="{$styleRoot}/theme/palette.css?v3.5.1" rel="stylesheet">
 
     <!-- Component library -->
-    <link href="{$styleRoot}/theme/styles.css?v3.5.0" rel="stylesheet">
+    <link href="{$styleRoot}/theme/styles.css?v3.5.1" rel="stylesheet">
 
     {block name="extra-stylesheets"}{/block}
 </head>


### PR DESCRIPTION
Bumps the style bundle submodule to tag `v3.5.1`. Note this tag does not have an updated build so the files will need to be generated correctly before deploying.