### PR TITLE
Add a summary field to post data, and show this in RSS and Open Graph tags

### DIFF
--- a/setup/database.sql
+++ b/setup/database.sql
@@ -14,6 +14,7 @@ CREATE TABLE posts (
   post_id TEXT UNIQUE,
   title TEXT,
   content TEXT,
+  summary TEXT,
   timestamp INTEGER,
   modified_timestamp INTEGER,
   published INTEGER DEFAULT 0,

--- a/src/model/post.php
+++ b/src/model/post.php
@@ -10,6 +10,7 @@ class Post
     public readonly string $id;
     public readonly string $title;
     public readonly string $content;
+    public readonly ?string $summary;
     public readonly int $timestamp;
     public readonly ?int $modified;
     public readonly array $tags;
@@ -25,6 +26,7 @@ class Post
         $this->id = $row['post_id'];
         $this->title = $row['title'];
         $this->content = $row['content'];
+        $this->summary = $row['summary'];
         $this->timestamp = $row['timestamp'];
         $this->modified = $row['modified_timestamp'];
         $this->tags = explode(' ', $row['tags']);

--- a/src/templates/layout/wrapper.tpl
+++ b/src/templates/layout/wrapper.tpl
@@ -1,7 +1,7 @@
 {* Smarty template: main page wrapper *}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: https://ogp.me/ns#">
 
 {include file="./html-head.tpl"}
 

--- a/src/templates/pages/rss.tpl
+++ b/src/templates/pages/rss.tpl
@@ -13,7 +13,11 @@
             <pubDate>{$post->timestamp|date_format:DateTime::RSS}</pubDate>
             <link>https://jbrowne.io/journal/post/{$post->id}</link>
             <guid>https://jbrowne.io/journal/post/{$post->id}</guid>
-            <description>{$post->content|readTime}. Tagged {$post->tags|join:', '}</description>
+            <description>
+            {if isset($post->summary)}{$post->summary}
+
+            {/if}{$post->content|readTime}. Tagged {$post->tags|join:', '}
+            </description>
         </item>
 {/foreach}
 

--- a/src/templates/pages/single-post.tpl
+++ b/src/templates/pages/single-post.tpl
@@ -6,6 +6,13 @@
 
 {block name="extra-stylesheets"}
     <link href="https://jbrowne.io/rss/journal" rel="alternate" type="application/rss+xml" title="Jason Browne’s Journal">
+    {if isset($post)}
+        <meta property="og:title" content="{$post->title}" />
+        {if isset($post->summary)}<meta property="og:description" content="{$post->summary}" />{/if}
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://jbrowne.io/rss/journal/post/{$post->id}" />
+        <meta property="og:image" content="https://jbrowne.io/android-chrome-256x256.png" />
+    {/if}
 {/block}
 
 {block name="page-content"}

--- a/tests/mocks/post.mock.php
+++ b/tests/mocks/post.mock.php
@@ -8,6 +8,7 @@ const MOCK_POST_ROW = [
     'post_id' => 'post-id',
     'title' => 'title',
     'content' => 'content',
+    'summary' => 'summary',
     'timestamp' => 1234567890,
     'modified_timestamp' => null,
     'tags' => 'abc',

--- a/tests/model/post.test.php
+++ b/tests/model/post.test.php
@@ -8,6 +8,7 @@ describe('Post object', function () {
         expect($post->id)->toBe(MOCK_POST_ROW['post_id']);
         expect($post->title)->toBe(MOCK_POST_ROW['title']);
         expect($post->content)->toBe(MOCK_POST_ROW['content']);
+        expect($post->summary)->toBe(MOCK_POST_ROW['summary']);
         expect($post->timestamp)->toBe(MOCK_POST_ROW['timestamp']);
         expect($post->modified)->toBe(MOCK_POST_ROW['modified_timestamp']);
         expect($post->tags)->toBe(explode(' ', MOCK_POST_ROW['tags']));


### PR DESCRIPTION
Adds a summary field to the posts table, which is null by default.

This summary is then used in the RSS feed to add more context to a post, along with new header tags defined by the [Open Graph protocol](https://ogp.me/) to make posts more descriptive when sharing to social media.

Further thinking may be required as the preview rendered for Open Graph applications is sparse if no description is provided.

## Example of the change in an RSS feed reader `Betterbird 128.14.0esr-bb32 (64-bit)`
<img width="717" height="134" alt="Screenshot_20250828_124354" src="https://github.com/user-attachments/assets/1b418a0e-37ca-4bb6-88a1-19a0062e8ae9" />

## Example of the change when the link is posted to Discord
<img width="349" height="199" alt="Screenshot_20250828_124412" src="https://github.com/user-attachments/assets/39b46177-3d44-499f-93d2-9353c8184ce5" />